### PR TITLE
Add user admin tools and profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is a simple PHP-based web portal designed for corporate healthcare personne
 - **Procedure Documents** (`procedure.php`)
 - **User Login/Registration** (`login.php`, `register.php`)
 - **Admin Panel** (`admin.php`)
+- **User Profiles** (`profile.php`)
 
 ## Usage
 
@@ -48,6 +49,14 @@ CREATE TABLE procedures (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(100) NOT NULL,
     file VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE profiles (
+    user_id INT PRIMARY KEY,
+    full_name VARCHAR(100) NOT NULL,
+    department VARCHAR(100) NOT NULL,
+    phone VARCHAR(20) NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );
 ```
 

--- a/index.php
+++ b/index.php
@@ -16,6 +16,7 @@ function render_menu() {
 function render_auth() {
     if (isset($_SESSION['user'])) {
         echo "<span class='navbar-text me-2'>Merhaba " . htmlspecialchars($_SESSION['user']) . "</span>";
+        echo "<a class='btn btn-light btn-sm me-2' href='profile.php'>Profil</a>";
         echo "<a class='btn btn-outline-light btn-sm me-2' href='logout.php'>Çıkış</a>";
         if ($_SESSION['role'] == 'admin') {
             echo "<a class='btn btn-light btn-sm' href='admin.php'>Admin Panel</a>";


### PR DESCRIPTION
## Summary
- let admins create users and change roles
- add new profile page
- show profile link when logged in
- document profile table

## Testing
- `php --version` *(fails: command not found)*
- `php -l index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684083cb54b48330978f83b24d587c0d