### PR TITLE
Fix chat scroll and document node setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,14 @@ Example using PHP's built-in server:
 php -S localhost:8000
 ```
 
-The messaging interface uses a small WebSocket server written in Node.js. Start it in a separate terminal:
+The messaging interface uses a small WebSocket server written in Node.js.
+Install the dependencies once and start it in a separate terminal:
+
+```bash
+npm install
+```
+
+Then run the WebSocket server:
 
 ```bash
 node ws-server.js

--- a/style.css
+++ b/style.css
@@ -10,7 +10,7 @@ body {
     box-shadow: 0 4px 10px rgba(0,0,0,0.1);
     border: none;
 }
-# Chat styles
+/* Chat styles */
 #chatBox {height:60vh; overflow-y:auto;}
 .bubble {background:#e9ecef; border-radius:12px; padding:6px 10px; margin-bottom:4px; max-width:80%; position:relative;}
 .bubble.mine {background:#d0ebff; margin-left:auto;}


### PR DESCRIPTION
## Summary
- document `npm install` step in README before running the WebSocket server
- fix comment in `style.css` so chat container styling is applied

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684090689db48330b03493d612e4ccb2