### PR TITLE
Add sticky chat header and online status

### DIFF
--- a/style.css
+++ b/style.css
@@ -11,12 +11,21 @@ body {
     border: none;
 }
 /* Chat styles */
+.chat-header{position:sticky;top:0;z-index:1020;background:#fff;}
 #chatBox {height:60vh; overflow-y:auto;}
-.bubble {background:#e9ecef; border-radius:12px; padding:6px 10px; margin-bottom:4px; max-width:80%; position:relative;}
+.bubble {background:#e9ecef; border-radius:12px; padding:6px 10px; margin-bottom:4px; max-width:80%; position:relative; word-wrap:break-word; overflow-wrap:anywhere; white-space:pre-wrap;}
 .bubble.mine {background:#d0ebff; margin-left:auto;}
 .bubble.theirs {background:#f1f3f5; margin-right:auto;}
 .bubble .meta {font-size:0.75rem; color:#6c757d; text-align:right;}
 .bubble .status {margin-left:4px; animation:fadein 0.3s;}
+#onlineDot{width:10px;height:10px;}
+@media (max-width:576px){
+  #chatHeader .full-name{display:none;}
+  #chatHeader .short-name{display:inline;}
+}
+@media (min-width:577px){
+  #chatHeader .short-name{display:none;}
+}
 @keyframes fadein {from{opacity:0;} to{opacity:1;}}
 @media (max-width:768px){
   #usersCol{display:none;}


### PR DESCRIPTION
## Summary
- keep long messages inside chat bubbles
- add sticky chat header with user avatar and name
- show online status via WebSocket presence broadcast

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840921fcbd883309fd5c2f7da2bc3c6