### PR TITLE
Fix profile picture persistence

### DIFF
--- a/profile.php
+++ b/profile.php
@@ -20,6 +20,9 @@ $stmt = $pdo->prepare('SELECT COUNT(*) FROM messages WHERE receiver_id = ? AND i
 $stmt->execute([$userId]);
 $unreadCount = $stmt->fetchColumn();
 $upload = '';
+$stmt = $pdo->prepare('SELECT full_name, department, phone, birthdate, picture FROM profiles WHERE user_id = ?');
+$stmt->execute([$userId]);
+$profile = $stmt->fetch(PDO::FETCH_ASSOC) ?: ['full_name' => '', 'department' => '', 'phone' => '', 'birthdate' => '', 'picture' => ''];
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if(isset($_POST['change_password'])){
         $current = $_POST['current_password'] ?? '';


### PR DESCRIPTION
## Summary
- prevent loss of profile picture when saving without new upload

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68409c1bf7448330925bf5a687cb05a7