### PR TITLE
Add roles and role-based homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This is a simple PHP-based web portal designed for corporate healthcare personne
 - **User Login/Registration** (`pages/login.php`, `pages/register.php`)
 - **Admin Panel** (`pages/admin.php`)
 - **User Profiles** (`pages/profile.php`)
+- **Role-based Home Page** with widgets for Doctor, Nurse and Secretary
 
 The main scripts are placed under the `pages/` directory while reusable code
 resides in `includes/`. Static assets such as the stylesheet live in
@@ -115,3 +116,4 @@ node ws-server.js
 ```
 
 Navigate to `http://localhost:8000` in your browser. Register a user and log in to access the modules. Insert an admin account in the `users` table (for example `admin` / `admin123`).
+Additional roles such as `doctor`, `nurse` and `secretary` can also be assigned to users via the admin panel.

--- a/index.php
+++ b/index.php
@@ -76,7 +76,9 @@ function render_auth($count) {
     <div class="container my-4">
     <section class="card p-4">
         <?php
-        if (in_array($module, $protected)) {
+        if ($module === 'home') {
+            include 'modules/home.php';
+        } elseif (in_array($module, $protected)) {
             $path = 'modules/' . $module . '.php';
             if (file_exists($path)) {
                 include $path;
@@ -84,7 +86,7 @@ function render_auth($count) {
                 echo '<p>Modül bulunamadı.</p>';
             }
         } else {
-            echo "<p>Hoş geldiniz! Modüllerden birini seçiniz.</p>";
+            echo '<p>Modül bulunamadı.</p>';
         }
         ?>
     </section>

--- a/modules/home.php
+++ b/modules/home.php
@@ -1,0 +1,93 @@
+<?php
+$role = $_SESSION['role'] ?? 'guest';
+$user = $_SESSION['user'] ?? 'Ziyaretçi';
+?>
+<h2 class="mb-3">Merhaba <?php echo htmlspecialchars($user); ?></h2>
+<?php if(!isset($_SESSION['user'])): ?>
+<p>Portal özelliklerine erişmek için lütfen giriş yapın.</p>
+<?php else: ?>
+<?php if($role === 'doctor'): ?>
+<div class="row g-3">
+    <div class="col-md-4">
+        <div class="card">
+            <div class="card-header">Hasta Listesi</div>
+            <div class="card-body">
+                <p>Görevli olduğunuz hastaların özet bilgileri.</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card">
+            <div class="card-header">Randevular</div>
+            <div class="card-body">
+                <p>Yaklaşan randevularınızı görüntüleyin.</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card">
+            <div class="card-header">Duyurular</div>
+            <div class="card-body">
+                <p>Doktorlara özel son duyurular.</p>
+            </div>
+        </div>
+    </div>
+</div>
+<?php elseif($role === 'nurse'): ?>
+<div class="row g-3">
+    <div class="col-md-4">
+        <div class="card">
+            <div class="card-header">İlaç Takip</div>
+            <div class="card-body">
+                <p>Hastaların ilaç planlarını kontrol edin.</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card">
+            <div class="card-header">Vardiyalarım</div>
+            <div class="card-body">
+                <p>Yaklaşan vardiya bilgileri.</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card">
+            <div class="card-header">Bildirimler</div>
+            <div class="card-body">
+                <p>Hemşirelere özel güncellemeler.</p>
+            </div>
+        </div>
+    </div>
+</div>
+<?php elseif($role === 'secretary'): ?>
+<div class="row g-3">
+    <div class="col-md-4">
+        <div class="card">
+            <div class="card-header">Randevu Yönetimi</div>
+            <div class="card-body">
+                <p>Günlük randevu kayıtlarını düzenleyin.</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card">
+            <div class="card-header">Hasta Karşılama</div>
+            <div class="card-body">
+                <p>Yeni gelen hastaları karşılamak için notlar.</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card">
+            <div class="card-header">Duyurular</div>
+            <div class="card-body">
+                <p>Sekreterlere yönelik bilgilendirmeler.</p>
+            </div>
+        </div>
+    </div>
+</div>
+<?php else: ?>
+<p>Portal modüllerine menüden erişebilirsiniz.</p>
+<?php endif; ?>
+<?php endif; ?>

--- a/pages/admin.php
+++ b/pages/admin.php
@@ -161,6 +161,9 @@ $profiles = $pdo->query('SELECT user_id, full_name, department, phone, birthdate
                         <select name="role" class="form-select">
                             <option value="user">user</option>
                             <option value="admin">admin</option>
+                            <option value="doctor">doctor</option>
+                            <option value="nurse">nurse</option>
+                            <option value="secretary">secretary</option>
                         </select>
                     </div>
                     <div class="col-md-2"><button class="btn btn-primary w-100">Ekle</button></div>
@@ -179,6 +182,9 @@ $profiles = $pdo->query('SELECT user_id, full_name, department, phone, birthdate
                                     <select name="role" class="form-select form-select-sm me-2">
                                         <option value="user" <?php if ($info['role']=='user') echo 'selected'; ?>>user</option>
                                         <option value="admin" <?php if ($info['role']=='admin') echo 'selected'; ?>>admin</option>
+                                        <option value="doctor" <?php if ($info['role']=='doctor') echo 'selected'; ?>>doctor</option>
+                                        <option value="nurse" <?php if ($info['role']=='nurse') echo 'selected'; ?>>nurse</option>
+                                        <option value="secretary" <?php if ($info['role']=='secretary') echo 'selected'; ?>>secretary</option>
                                     </select>
                                     <button class="btn btn-sm btn-secondary">Kaydet</button>
                                 </form>

--- a/pages/register.php
+++ b/pages/register.php
@@ -10,8 +10,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($stmt->fetchColumn() > 0) {
         $message = 'Kullanıcı adı zaten mevcut';
     } else {
+        $r = $_POST['role'] ?? 'user';
         $stmt = $pdo->prepare('INSERT INTO users (username, password, role) VALUES (?, ?, ?)');
-        $stmt->execute([$u, password_hash($p, PASSWORD_DEFAULT), 'user']);
+        $stmt->execute([$u, password_hash($p, PASSWORD_DEFAULT), $r]);
         $message = 'Kayıt başarılı. Giriş yapabilirsiniz.';
     }
 }
@@ -35,6 +36,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             </div>
             <div class="mb-3">
                 <input type="password" class="form-control" name="password" placeholder="Şifre" required>
+            </div>
+            <div class="mb-3">
+                <select name="role" class="form-select">
+                    <option value="user">user</option>
+                    <option value="doctor">doctor</option>
+                    <option value="nurse">nurse</option>
+                    <option value="secretary">secretary</option>
+                </select>
             </div>
             <button type="submit" class="btn btn-primary w-100">Kayıt Ol</button>
         </form>


### PR DESCRIPTION
## Summary
- support additional `doctor`, `nurse` and `secretary` user roles
- show role-specific widgets on the new home module
- allow admins and registration form to assign the new roles
- update README with the new feature

## Testing
- `php -l index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68417a033df483308c8ba254d9ac4b01