### PR TITLE
Fix login flow and profile view

### DIFF
--- a/assets/profile-view.css
+++ b/assets/profile-view.css
@@ -298,6 +298,14 @@ body {
   font-weight: 500;
   font-size: 14px;
   margin-bottom: 5px;
+  display: flex;
+  justify-content: space-between;
+}
+
+.card-item-date {
+  font-size: 12px;
+  color: #6f6f7b;
+  margin-left: 8px;
 }
 
 .card-item-desc {

--- a/pages/admin.php
+++ b/pages/admin.php
@@ -504,6 +504,21 @@ $hide_register_button = $settings['hide_register_button'] ?? '0';
         }
         toggleTo();
         if(fromSel) fromSel.addEventListener('change', toggleTo);
+
+        const regOpenChk = document.getElementById('registrations_open');
+        const hideRegBtnChk = document.getElementById('hide_register_button');
+        function toggleHideOption(){
+            if(regOpenChk && hideRegBtnChk){
+                if(regOpenChk.checked){
+                    hideRegBtnChk.checked = false;
+                    hideRegBtnChk.disabled = true;
+                }else{
+                    hideRegBtnChk.disabled = false;
+                }
+            }
+        }
+        toggleHideOption();
+        if(regOpenChk) regOpenChk.addEventListener('change', toggleHideOption);
     </script>
 </body>
 </html>

--- a/pages/login.php
+++ b/pages/login.php
@@ -5,6 +5,7 @@ require __DIR__ . '/../includes/settings.php';
 $registrations_open = get_setting($pdo, 'registrations_open', '1');
 $hide_register_button = get_setting($pdo, 'hide_register_button', '0');
 $error = '';
+$success = false;
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $u = $_POST['username'] ?? '';
     $p = $_POST['password'] ?? '';
@@ -16,8 +17,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $_SESSION['role'] = $user['role'];
         $up = $pdo->prepare('UPDATE users SET last_active=NOW() WHERE username=?');
         $up->execute([$user['username']]);
-        header('Location: ../index.php');
-        exit;
+        $success = true;
     } else {
         $error = 'Hatalı kullanıcı adı veya şifre';
     }
@@ -52,13 +52,28 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 </div>
                 <div class="links">
                     <a href="#">Şifremi Unuttum</a>
-                    <?php if ($registrations_open || !$hide_register_button): ?>
+                    <?php if ($registrations_open == '1' && $hide_register_button != '1'): ?>
                     <a href="register.php">Kayıt Ol</a>
                     <?php endif; ?>
                 </div>
             </form>
         </div>
     </div>
+    <?php if ($success): ?>
+    <div class="toast-container position-fixed bottom-0 start-50 translate-middle-x p-3">
+        <div id="loginToast" class="toast align-items-center text-bg-success border-0" role="alert">
+            <div class="d-flex">
+                <div class="toast-body">Giriş başarılı, yönlendiriliyor.</div>
+            </div>
+        </div>
+    </div>
+    <script>
+        const toastEl = document.getElementById('loginToast');
+        const toast = new bootstrap.Toast(toastEl, {delay: 3000});
+        toast.show();
+        setTimeout(()=>{ window.location = '../index.php'; }, 3000);
+    </script>
+    <?php endif; ?>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/pages/view_profile.php
+++ b/pages/view_profile.php
@@ -57,8 +57,13 @@ $experiences = $expStmt->fetchAll();
         <div class="card-subtitle">DENEYİM</div>
         <div class="card-timeline">
           <?php if($experiences): foreach($experiences as $e): ?>
-          <div class="card-item" data-year="<?php echo htmlspecialchars($e['exp_date']); ?>">
-            <div class="card-item-title"><?php echo htmlspecialchars($e['title']); ?></div>
+          <?php $year = $e['exp_date'] ? date('Y', strtotime($e['exp_date'])) : '-'; ?>
+          <?php $fulldate = $e['exp_date'] ? date('d.m.Y', strtotime($e['exp_date'])) : '-'; ?>
+          <div class="card-item" data-year="<?php echo htmlspecialchars($year); ?>">
+            <div class="card-item-title">
+              <?php echo htmlspecialchars($e['title']); ?>
+              <span class="card-item-date"><?php echo htmlspecialchars($fulldate); ?></span>
+            </div>
           </div>
           <?php endforeach; else: ?>
           <div class="card-item" data-year="-">


### PR DESCRIPTION
## Summary
- show toast and delay redirect after login success
- show register link only when registrations are open and not hidden
- allow admin to disable register button only when registrations are closed
- improve profile experience timeline formatting

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68418a9e26ec83308fb77003c4e533ee