### PR TITLE
Add editable landing page management

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ CREATE TABLE settings (
     value VARCHAR(50) NOT NULL
 );
 
+CREATE TABLE site_pages (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    slug VARCHAR(100) UNIQUE NOT NULL,
+    title VARCHAR(100) NOT NULL,
+    content TEXT NOT NULL
+);
+
 INSERT INTO settings (name, value) VALUES
     ('registrations_open','1'),
     ('hide_register_button','0');
@@ -107,6 +114,12 @@ INSERT INTO modules (name, file) VALUES
     ('Eğitimler','training'),
     ('Sınavlar','exam'),
     ('Prosedürler','procedure');
+
+-- Example landing pages
+INSERT INTO site_pages (slug, title, content) VALUES
+    ('home','Ana Sayfa','<h2>Hoş geldiniz</h2>'),
+    ('hakkimizda','Hakkımızda','<p>Hakkımızda içerik</p>'),
+    ('biz-kimiz','Biz Kimiz','<p>Biz Kimiz içerik</p>');
 ```
 
 Edit `includes/db.php` if your database credentials differ from the defaults.

--- a/includes/pages.php
+++ b/includes/pages.php
@@ -1,0 +1,11 @@
+<?php
+function get_public_pages($pdo){
+    return $pdo->query("SELECT slug, title FROM site_pages ORDER BY id")->fetchAll();
+}
+
+function get_page_content($pdo, $slug){
+    $stmt = $pdo->prepare("SELECT title, content FROM site_pages WHERE slug=?");
+    $stmt->execute([$slug]);
+    return $stmt->fetch();
+}
+?>

--- a/index.php
+++ b/index.php
@@ -3,6 +3,10 @@ session_start();
 require __DIR__ . '/includes/db.php';
 require __DIR__ . '/includes/activity.php';
 require __DIR__ . '/includes/settings.php';
+if (!isset($_SESSION['user'])) {
+    header('Location: landing.php');
+    exit;
+}
 update_activity($pdo);
 $registrations_open = get_setting($pdo, 'registrations_open', '1');
 $hide_register_button = get_setting($pdo, 'hide_register_button', '0');

--- a/landing.php
+++ b/landing.php
@@ -1,0 +1,41 @@
+<?php
+session_start();
+require __DIR__ . '/includes/db.php';
+require __DIR__ . '/includes/pages.php';
+$pages = get_public_pages($pdo);
+$slug = $_GET['p'] ?? 'home';
+$page = get_page_content($pdo, $slug);
+?>
+<!DOCTYPE html>
+<html lang='tr'>
+<head>
+    <meta charset='UTF-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title><?php echo htmlspecialchars($page['title'] ?? 'Portal'); ?></title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+    <div class="container">
+        <a class="navbar-brand" href="landing.php">Portal</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="mainNav">
+            <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                <?php foreach($pages as $p): ?>
+                    <li class="nav-item"><a class="nav-link <?php if($slug==$p['slug']) echo 'active'; ?>" href="landing.php?p=<?php echo htmlspecialchars($p['slug']); ?>"><?php echo htmlspecialchars($p['title']); ?></a></li>
+                <?php endforeach; ?>
+            </ul>
+            <a class="btn btn-light btn-sm" href="pages/login.php">Giriş Yap</a>
+        </div>
+    </div>
+</nav>
+<div class="container my-4">
+    <div class="card p-4">
+        <?php echo $page ? $page['content'] : '<p>Sayfa bulunamadı.</p>'; ?>
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/pages/admin.php
+++ b/pages/admin.php
@@ -68,6 +68,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $stmt = $pdo->prepare('DELETE FROM modules WHERE id = ?');
                 $stmt->execute([$_POST['id']]);
             }
+        } elseif ($section === 'pages') {
+            if ($action === 'add') {
+                $stmt = $pdo->prepare('INSERT INTO site_pages (title, slug, content) VALUES (?,?,?)');
+                $stmt->execute([$_POST['title'], $_POST['slug'], $_POST['content']]);
+            } elseif ($action === 'update') {
+                $stmt = $pdo->prepare('UPDATE site_pages SET title=?, slug=?, content=? WHERE id=?');
+                $stmt->execute([$_POST['title'], $_POST['slug'], $_POST['content'], $_POST['id']]);
+            } elseif ($action === 'delete') {
+                $stmt = $pdo->prepare('DELETE FROM site_pages WHERE id = ?');
+                $stmt->execute([$_POST['id']]);
+            }
         } elseif ($section === 'experiences') {
             if ($action === 'add') {
                 $stmt = $pdo->prepare('INSERT INTO experiences (user_id,title,exp_date) VALUES (?,?,?)');
@@ -128,6 +139,7 @@ $trainings = $pdo->query('SELECT id, title, description FROM trainings ORDER BY 
 $exams = $pdo->query('SELECT id, title, date FROM exams ORDER BY date')->fetchAll();
 $procedures = $pdo->query('SELECT id, name, file FROM procedures ORDER BY name')->fetchAll();
 $modules = $pdo->query('SELECT id, name, file FROM modules ORDER BY id')->fetchAll();
+$site_pages = $pdo->query('SELECT id, slug, title, content FROM site_pages ORDER BY id')->fetchAll();
 $experiences = $pdo->query('SELECT e.id, e.user_id, u.username, e.title, e.exp_date FROM experiences e JOIN users u ON e.user_id=u.id ORDER BY e.exp_date DESC')->fetchAll();
 $profiles = $pdo->query('SELECT user_id, full_name, department, phone, birthdate FROM profiles')->fetchAll();
 $settings = $pdo->query('SELECT name,value FROM settings')->fetchAll(PDO::FETCH_KEY_PAIR);
@@ -164,6 +176,9 @@ $hide_register_button = $settings['hide_register_button'] ?? '0';
             </li>
             <li class="nav-item" role="presentation">
                 <button class="nav-link" id="modules-tab" data-bs-toggle="tab" data-bs-target="#modules" type="button" role="tab">Modüller</button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link" id="pages-tab" data-bs-toggle="tab" data-bs-target="#pages" type="button" role="tab">Sayfalar</button>
             </li>
             <li class="nav-item" role="presentation">
                 <button class="nav-link" id="experiences-tab" data-bs-toggle="tab" data-bs-target="#experiences" type="button" role="tab">Deneyimler</button>
@@ -336,6 +351,34 @@ $hide_register_button = $settings['hide_register_button'] ?? '0';
                         </li>
                     <?php endforeach; ?>
                 </ul>
+            </div>
+            <div class="tab-pane fade" id="pages" role="tabpanel">
+                <form method="post" class="row g-2 mb-3">
+                    <input type="hidden" name="section" value="pages">
+                    <input type="hidden" name="action" value="add">
+                    <div class="col-md-3"><input type="text" name="title" class="form-control" placeholder="Başlık" required></div>
+                    <div class="col-md-3"><input type="text" name="slug" class="form-control" placeholder="slug" required></div>
+                    <div class="col-md-4"><input type="text" name="content" class="form-control" placeholder="İçerik" required></div>
+                    <div class="col-md-2"><button class="btn btn-primary w-100">Ekle</button></div>
+                </form>
+                <table class="table table-sm table-striped">
+                    <tr><th>Başlık</th><th>Slug</th><th>İçerik</th><th></th></tr>
+                    <?php foreach($site_pages as $pg): ?>
+                        <tr>
+                            <form method="post" class="d-flex">
+                                <input type="hidden" name="section" value="pages">
+                                <input type="hidden" name="id" value="<?php echo $pg['id']; ?>">
+                                <td><input type="text" name="title" class="form-control form-control-sm" value="<?php echo htmlspecialchars($pg['title']); ?>"></td>
+                                <td><input type="text" name="slug" class="form-control form-control-sm" value="<?php echo htmlspecialchars($pg['slug']); ?>"></td>
+                                <td><textarea name="content" class="form-control form-control-sm" rows="1"><?php echo htmlspecialchars($pg['content']); ?></textarea></td>
+                                <td>
+                                    <button name="action" value="update" class="btn btn-sm btn-secondary me-1">Kaydet</button>
+                                    <button name="action" value="delete" class="btn btn-sm btn-danger">Sil</button>
+                                </td>
+                            </form>
+                        </tr>
+                    <?php endforeach; ?>
+                </table>
             </div>
             <div class="tab-pane fade" id="experiences" role="tabpanel">
                 <form method="post" class="row g-2 mb-3">


### PR DESCRIPTION
## Summary
- create table instructions for site_pages
- add page helper functions
- redirect visitors to new landing page
- implement landing page with dynamic content
- extend admin panel with page management

## Testing
- `php -l landing.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68419075d62c8330afa9943cf93a192a