### PR TITLE
Fix login redirect and password toggle position

### DIFF
--- a/assets/login.css
+++ b/assets/login.css
@@ -92,9 +92,10 @@ body {
 }
 .login .inputBx .toggle-password {
   position: absolute;
-  right: 20px;
+  right: 30px;
   top: 50%;
   transform: translateY(-50%);
+  font-size: 1.2em;
   cursor: pointer;
   color: #fff;
 }

--- a/pages/login.php
+++ b/pages/login.php
@@ -5,7 +5,6 @@ require __DIR__ . '/../includes/settings.php';
 $registrations_open = get_setting($pdo, 'registrations_open', '1');
 $hide_register_button = get_setting($pdo, 'hide_register_button', '0');
 $error = '';
-$success = false;
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $u = $_POST['username'] ?? '';
     $p = $_POST['password'] ?? '';
@@ -17,7 +16,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $_SESSION['role'] = $user['role'];
         $up = $pdo->prepare('UPDATE users SET last_active=NOW() WHERE username=?');
         $up->execute([$user['username']]);
-        $success = true;
+        header('Location: ../index.php');
+        exit;
     } else {
         $error = 'Hatalı kullanıcı adı veya şifre';
     }
@@ -61,21 +61,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             </form>
         </div>
     </div>
-    <?php if ($success): ?>
-    <div class="toast-container position-fixed bottom-0 start-50 translate-middle-x p-3">
-        <div id="loginToast" class="toast align-items-center text-bg-success border-0" role="alert">
-            <div class="d-flex">
-                <div class="toast-body">Giriş başarılı, yönlendiriliyor.</div>
-            </div>
-        </div>
-    </div>
-    <script>
-        const toastEl = document.getElementById('loginToast');
-        const toast = new bootstrap.Toast(toastEl, {delay: 3000});
-        toast.show();
-        setTimeout(()=>{ window.location = '../index.php'; }, 3000);
-    </script>
-    <?php endif; ?>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script>
         document.querySelectorAll('.toggle-password').forEach(function(el) {


### PR DESCRIPTION
## Summary
- redirect immediately to index after successful login
- tune password toggle icon placement on login/register screens

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684192b283108330984679a21855e4b9