### PR TITLE
Add site name setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ CREATE TABLE site_pages (
 
 INSERT INTO settings (name, value) VALUES
     ('registrations_open','1'),
-    ('hide_register_button','0');
+    ('hide_register_button','0'),
+    ('site_name','Sağlık Personeli Portalı');
 
 -- Example initial modules
 INSERT INTO modules (name, file) VALUES

--- a/index.php
+++ b/index.php
@@ -10,6 +10,7 @@ if (!isset($_SESSION['user'])) {
 update_activity($pdo);
 $registrations_open = get_setting($pdo, 'registrations_open', '1');
 $hide_register_button = get_setting($pdo, 'hide_register_button', '0');
+$site_name = get_setting($pdo, 'site_name', 'Sağlık Personeli Portalı');
 $mods = $pdo->query('SELECT name, file FROM modules ORDER BY id')->fetchAll();
 $protected = array_column($mods, 'file');
 $module = isset($_GET['module']) ? $_GET['module'] : 'home';
@@ -63,14 +64,14 @@ function render_auth($count, $registrations_open, $hide_register_button) {
 <head>
     <meta charset='UTF-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Sağlık Personeli Portalı</title>
+    <title><?php echo htmlspecialchars($site_name); ?></title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
         <div class="container">
-            <a class="navbar-brand" href="index.php">Sağlık Personeli Portalı</a>
+            <a class="navbar-brand" href="index.php"><?php echo htmlspecialchars($site_name); ?></a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/landing.php
+++ b/landing.php
@@ -1,7 +1,9 @@
 <?php
 session_start();
 require __DIR__ . '/includes/db.php';
+require __DIR__ . '/includes/settings.php';
 require __DIR__ . '/includes/pages.php';
+$site_name = get_setting($pdo, 'site_name', 'Portal');
 $pages = get_public_pages($pdo);
 $slug = $_GET['p'] ?? 'home';
 $page = get_page_content($pdo, $slug);
@@ -11,13 +13,14 @@ $page = get_page_content($pdo, $slug);
 <head>
     <meta charset='UTF-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title><?php echo htmlspecialchars($page['title'] ?? 'Portal'); ?></title>
+    <?php $title = $page['title'] ?? $site_name; ?>
+    <title><?php echo htmlspecialchars($title); ?></title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
     <div class="container">
-        <a class="navbar-brand" href="landing.php">Portal</a>
+        <a class="navbar-brand" href="landing.php"><?php echo htmlspecialchars($site_name); ?></a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav">
             <span class="navbar-toggler-icon"></span>
         </button>

--- a/pages/admin.php
+++ b/pages/admin.php
@@ -99,8 +99,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             if ($action === 'update') {
                 $reg = isset($_POST['registrations_open']) ? '1' : '0';
                 $hide = isset($_POST['hide_register_button']) ? '1' : '0';
+                $name = trim($_POST['site_name'] ?? '');
                 $pdo->prepare('REPLACE INTO settings (name,value) VALUES ("registrations_open",?)')->execute([$reg]);
                 $pdo->prepare('REPLACE INTO settings (name,value) VALUES ("hide_register_button",?)')->execute([$hide]);
+                if($name !== ''){
+                    $pdo->prepare('REPLACE INTO settings (name,value) VALUES ("site_name",?)')->execute([$name]);
+                }
             }
         } elseif ($section === 'admin_messages') {
             if ($action === 'send') {
@@ -145,6 +149,7 @@ $profiles = $pdo->query('SELECT user_id, full_name, department, phone, birthdate
 $settings = $pdo->query('SELECT name,value FROM settings')->fetchAll(PDO::FETCH_KEY_PAIR);
 $registrations_open = $settings['registrations_open'] ?? '1';
 $hide_register_button = $settings['hide_register_button'] ?? '0';
+$site_name = $settings['site_name'] ?? 'Sağlık Personeli Portalı';
 ?>
 <!DOCTYPE html>
 <html lang='tr'>
@@ -511,6 +516,10 @@ $hide_register_button = $settings['hide_register_button'] ?? '0';
                 <form method="post" class="mb-3">
                     <input type="hidden" name="section" value="settings">
                     <input type="hidden" name="action" value="update">
+                    <div class="mb-3">
+                        <label for="site_name" class="form-label">Web Site Adı</label>
+                        <input type="text" class="form-control" id="site_name" name="site_name" value="<?php echo htmlspecialchars($site_name); ?>">
+                    </div>
                     <div class="form-check form-switch mb-2">
                         <input class="form-check-input" type="checkbox" id="registrations_open" name="registrations_open" value="1" <?php if($registrations_open=='1') echo 'checked'; ?>>
                         <label class="form-check-label" for="registrations_open">Kayıtları Aç</label>


### PR DESCRIPTION
## Summary
- allow configuring site name via new settings option
- use the configured name in landing page, portal navbar and HTML title
- document the `site_name` default setting in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841991671848330a522e42d59ad2f27