### PR TITLE
Implement dark dashboard for personnel

### DIFF
--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -1,0 +1,82 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
+:root{
+  --accent:#0dd4a3;
+}
+body.home-dashboard{
+  font-family:'Inter',sans-serif;
+  font-size:15px;
+  line-height:1.5;
+  color:#fff;
+  background:linear-gradient(180deg,#0e1b2b,#142438);
+  min-height:100vh;
+  position:relative;
+}
+body.home-dashboard::before{
+  content:"";
+  position:fixed;inset:0;
+  background-image:url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMjAiIGhlaWdodD0iMTIwIiB2aWV3Qm94PSIwIDAgMTIwIDEyMCI+PHBhdGggZD0iTTYwIDAgTDYwIDEyMCBNMCA2MCBMMTIwIDYwIE0wIDAgTDEyMCAxMjAgTTEyMCAwIEwwIDEyMCIgc3Ryb2tlPSIlMjNmZmYiIHN0cm9rZS13aWR0aD0iMC41IiBzdHJva2Utb3BhY2l0eT0iMC4xNSIgZmlsbD0ibm9uZSIvPjwvc3ZnPg==");
+  opacity:0.08;
+  background-size:120px 120px;
+  pointer-events:none;
+  z-index:0;
+}
+.portal-nav{
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  padding:12px 24px;
+  position:fixed;
+  top:0;left:0;right:0;
+  background:rgba(14,27,43,0.8);
+  backdrop-filter:blur(6px);
+  box-shadow:0 2px 4px rgba(0,0,0,0.4);
+  z-index:10;
+}
+.portal-logo{font-size:24px;font-weight:700;text-transform:uppercase;}
+.nav-left{display:flex;flex-direction:column;line-height:1.2;}
+.nav-left .welcome{font-size:14px;margin-top:2px;}
+.role-pill{background:rgba(255,255,255,0.15);padding:2px 8px;border-radius:9999px;font-size:12px;margin-top:2px;display:inline-block;}
+.nav-right button,.nav-right a{background:none;border:none;color:#fff;margin-left:12px;font-size:16px;cursor:pointer;border-radius:8px;padding:6px;}
+.nav-right a.logout-btn{background:#ff3b3b;padding:6px 12px;}
+.nav-right button:hover,.nav-right a:hover{filter:brightness(1.2);}
+.dashboard{padding-top:80px;max-width:1200px;margin:0 auto;}
+.dashboard-grid{
+  display:grid;
+  grid-template-columns:repeat(4,1fr);
+  gap:24px;
+  padding:24px;
+}
+@media (max-width:1199px){
+.dashboard-grid{grid-template-columns:repeat(2,1fr);} }
+@media (max-width:767px){
+.dashboard-grid{grid-template-columns:repeat(1,1fr);} }
+.dashboard-card{
+  min-width:280px;min-height:260px;
+  background:rgba(255,255,255,0.04);
+  border:1px solid rgba(255,255,255,0.08);
+  border-radius:16px;
+  box-shadow:0 4px 10px rgba(0,0,0,0.4);
+  display:flex;flex-direction:column;align-items:center;justify-content:center;
+  position:relative;transition:transform .2s,filter .2s;
+  text-align:center;
+}
+.dashboard-card:hover{transform:scale(1.03);filter:brightness(1.2);}
+.dashboard-card h3{margin-top:12px;font-size:18px;font-weight:600;letter-spacing:0.5px;text-transform:uppercase;}
+.dashboard-card p{font-size:14px;color:rgba(255,255,255,0.6);}
+.status-badge{position:absolute;bottom:12px;left:12px;padding:2px 10px;border-radius:9999px;font-size:10px;font-weight:600;color:#fff;}
+.badge-green{background:linear-gradient(90deg,#0dd4a3,#0bad88);}
+.badge-blue{background:linear-gradient(90deg,#28c46b,#1aa957);}
+.badge-orange{background:linear-gradient(90deg,#ff9a28,#ff7a00);}
+.announcements{max-width:1000px;margin:24px auto;padding:24px;}
+.announcements h3{font-size:20px;margin-bottom:16px;color:#fff;}
+.announcement-item{border-bottom:1px solid rgba(255,255,255,0.1);padding:8px 0;}
+.announcement-item:last-child{border-bottom:none;}
+.announcement-item .title{font-weight:700;font-size:16px;display:block;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%;}
+.announcement-item .date{font-size:12px;color:#9fa6b2;}
+.announcements ul{max-height:400px;overflow-y:auto;padding:0;list-style:none;}
+.announcements ul::-webkit-scrollbar{width:6px;}
+.announcements ul::-webkit-scrollbar-track{background:transparent;}
+.announcements ul::-webkit-scrollbar-thumb{background:#0dd4a3;border-radius:3px;}
+.home-dashboard nav.navbar{display:none;}
+.home-dashboard section.card{background:transparent;border:none;box-shadow:none;padding:0;}
+.home-dashboard.light{filter:invert(1) hue-rotate(180deg);}

--- a/index.php
+++ b/index.php
@@ -67,6 +67,8 @@ function render_auth($count, $registrations_open, $hide_register_button) {
     <title><?php echo htmlspecialchars($site_name); ?></title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="assets/style.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link rel="stylesheet" href="assets/dashboard.css">
 </head>
 <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary">

--- a/modules/home.php
+++ b/modules/home.php
@@ -1,12 +1,109 @@
 <?php
 $role = $_SESSION['role'] ?? 'guest';
 $user = $_SESSION['user'] ?? 'Ziyaretçi';
+$full = $user;
+if(isset($_SESSION['user'])){
+    $stmt = $pdo->prepare('SELECT profiles.full_name FROM users LEFT JOIN profiles ON profiles.user_id = users.id WHERE users.username = ?');
+    $stmt->execute([$user]);
+    $fn = $stmt->fetchColumn();
+    if($fn){ $full = $fn; }
+}
+if($role === 'Normal Personel'):
+?>
+<nav class="portal-nav">
+<script>document.body.classList.add('home-dashboard');</script>
+  <div class="nav-left">
+    <div class="portal-logo">ACIBADEM PORTAL</div>
+    <div class="welcome">Hoşgeldiniz, <?php echo htmlspecialchars($full); ?></div>
+    <span class="role-pill">Normal Personel</span>
+  </div>
+  <div class="nav-right">
+    <button id="settingsBtn" aria-label="Ayarlar" role="button"><i class="fa-solid fa-gear"></i></button>
+    <button id="themeToggle" aria-label="Tema" role="button">🌙</button>
+    <a href="pages/logout.php" class="logout-btn" aria-label="Çıkış" role="button"><i class="fa-solid fa-arrow-right-from-bracket"></i> Çıkış</a>
+  </div>
+</nav>
+<div class="dashboard">
+  <div class="dashboard-grid">
+    <div class="dashboard-card" id="work-list">
+      <i class="fa-solid fa-calendar" style="color:#3fa7ff;font-size:48px;"></i>
+      <h3>ÇALIŞMA LİSTESİ</h3>
+      <p>Vardiyalarınızı ve mesai planınızı anında görün.</p>
+      <span class="status-badge badge-green">Güncel</span>
+    </div>
+    <div class="dashboard-card" id="procedure-read">
+      <i class="fa-solid fa-book" style="color:#0dd4a3;font-size:48px;"></i>
+      <h3>PROSEDÜR OKUMA</h3>
+      <p>Güncel prosedürlere hızla erişin, bilgilenin.</p>
+      <span class="status-badge badge-blue">12 Yeni</span>
+    </div>
+    <div class="dashboard-card" id="active-exams">
+      <i class="fa-solid fa-clipboard-check" style="color:#ff5555;font-size:48px;"></i>
+      <h3>AKTİF SINAVLAR</h3>
+      <p>Sınavlarınızı takip edin, başarınızı ölçün.</p>
+      <span class="status-badge badge-orange">3 Bekleyen</span>
+    </div>
+    <div class="dashboard-card" id="revised-procedures">
+      <i class="fa-solid fa-book" style="color:#3fa7ff;font-size:48px;"></i>
+      <h3>REVİZE PROSEDÜRLER</h3>
+      <p>En son güncellemeleri kaçırmayın, onaylayın.</p>
+      <span class="status-badge badge-blue">5 Yeni</span>
+    </div>
+    <div class="dashboard-card" id="trainings">
+      <i class="fa-solid fa-graduation-cap" style="color:#3fa7ff;font-size:48px;"></i>
+      <h3>EĞİTİMLER</h3>
+      <p>Kariyerinizi geliştirecek eğitimlere katılın.</p>
+      <span class="status-badge badge-blue">8 Aktif</span>
+    </div>
+    <div class="dashboard-card" id="games">
+      <i class="fa-solid fa-gamepad" style="color:#b54bff;font-size:48px;"></i>
+      <h3>OYUNLAR</h3>
+      <p>Öğrenirken eğlenin, bilginizi test edin.</p>
+      <span class="status-badge badge-blue">4 Yeni</span>
+    </div>
+    <div class="dashboard-card" id="podcast">
+      <i class="fa-solid fa-podcast" style="color:#ff9a28;font-size:48px;"></i>
+      <h3>PODCAST</h3>
+      <p>Sağlık ve liderlikte güncel kalın, dinleyin.</p>
+      <span class="status-badge badge-blue">6 Yeni Bölüm</span>
+    </div>
+    <div class="dashboard-card" id="performance">
+      <i class="fa-solid fa-chart-line" style="color:#0dd4a3;font-size:48px;"></i>
+      <h3>PERFORMANS</h3>
+      <p>Hedeflerinizi ve performansınızı takip edin.</p>
+      <span class="status-badge badge-orange">1 Yaklaşıyor</span>
+    </div>
+  </div>
+  <section class="announcements">
+    <h3>Duyurular ve Bilgilendirmeler</h3>
+    <ul>
+      <li class="announcement-item"><span class="title">Örnek duyuru metni buraya gelecek ve altmış karakteri geçmesi durumunda...</span><div class="date">2024-01-01</div></li>
+      <li class="announcement-item"><span class="title">İkinci duyuru metni için bir örnek içerik yer alır...</span><div class="date">2024-01-02</div></li>
+    </ul>
+  </section>
+</div>
+<script>
+  document.querySelectorAll('.dashboard-card').forEach(function(el){el.addEventListener('click',function(){console.log(el.id);});});
+  const btn=document.getElementById('themeToggle');
+  if(btn){
+    const st=localStorage.getItem('theme')||'dark';
+    if(st==='light') document.body.classList.add('light');
+    btn.textContent=st==='light'?'☀️':'🌙';
+    btn.addEventListener('click',function(){
+      document.body.classList.toggle('light');
+      const now=document.body.classList.contains('light')?'light':'dark';
+      btn.textContent=now==='light'?'☀️':'🌙';
+      localStorage.setItem('theme',now);
+    });
+  }
+</script>
+<?php
+else:
 ?>
 <h2 class="mb-3">Merhaba <?php echo htmlspecialchars($user); ?></h2>
 <?php if(!isset($_SESSION['user'])): ?>
 <p>Portal özelliklerine erişmek için lütfen giriş yapın.</p>
-<?php else: ?>
-<?php if($role === 'Sorumlu Hemşire'): ?>
+<?php elseif($role === 'Sorumlu Hemşire'): ?>
 <div class="row g-3">
     <div class="col-md-4">
         <div class="card">
@@ -56,33 +153,6 @@ $user = $_SESSION['user'] ?? 'Ziyaretçi';
             <div class="card-header">Bildirimler</div>
             <div class="card-body">
                 <p>Klinik eğitim hemşirelerine özel güncellemeler.</p>
-            </div>
-        </div>
-    </div>
-</div>
-<?php elseif($role === 'Normal Personel'): ?>
-<div class="row g-3">
-    <div class="col-md-4">
-        <div class="card">
-            <div class="card-header">Randevu Yönetimi</div>
-            <div class="card-body">
-                <p>Günlük randevu kayıtlarını düzenleyin.</p>
-            </div>
-        </div>
-    </div>
-    <div class="col-md-4">
-        <div class="card">
-            <div class="card-header">Hasta Karşılama</div>
-            <div class="card-body">
-                <p>Yeni gelen hastaları karşılamak için notlar.</p>
-            </div>
-        </div>
-    </div>
-    <div class="col-md-4">
-        <div class="card">
-            <div class="card-header">Duyurular</div>
-            <div class="card-body">
-                <p>Personellere yönelik bilgilendirmeler.</p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add new dashboard.css styles with dark theme design
- extend index to include Font Awesome and dashboard styles
- overhaul Normal Personel home page with grid cards, navbar, announcements and theme toggle

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68419c6d57cc83308bebc3a0ac5c9f68