### PR TITLE
Fix dark mode visibility

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -33,3 +33,26 @@ body {
   #usersCol{display:none;}
   #chatCol{flex:0 0 100%; max-width:100%;}
 }
+
+/* Theme styles */
+body.light {
+  background-color: #f8f9fa;
+  color: #212529;
+}
+body.dark {
+  background-color: #121212;
+  color: #f8f9fa;
+}
+body.dark .card {
+  background-color: #1e1e1e;
+  color: inherit;
+}
+body.dark .navbar {
+  background-color: #1f1f1f !important;
+}
+body.light .navbar {
+  background-color: #0d6efd !important;
+}
+body.dark a {
+  color: #86b7fe;
+}

--- a/assets/theme.js
+++ b/assets/theme.js
@@ -1,0 +1,18 @@
+document.addEventListener('DOMContentLoaded',function(){
+  const current = localStorage.getItem('theme') || 'light';
+  document.body.classList.add(current);
+  const toggle = document.getElementById('themeToggleGlobal');
+  function updateButton(theme){
+    if(toggle){ toggle.textContent = theme === 'dark' ? '☀️' : '🌙'; }
+  }
+  updateButton(current);
+  if(toggle){
+    toggle.addEventListener('click',function(){
+      document.body.classList.toggle('dark');
+      document.body.classList.toggle('light');
+      const now = document.body.classList.contains('dark') ? 'dark' : 'light';
+      localStorage.setItem('theme', now);
+      updateButton(now);
+    });
+  }
+});

--- a/index.php
+++ b/index.php
@@ -82,6 +82,7 @@ function render_auth($count, $registrations_open, $hide_register_button) {
                     <?php render_menu($mods); ?>
                 </ul>
                 <?php render_auth($unreadCount, $registrations_open, $hide_register_button); ?>
+                <button id="themeToggleGlobal" class="btn btn-outline-light btn-sm ms-2" type="button">🌙</button>
             </div>
         </div>
     </nav>
@@ -104,5 +105,6 @@ function render_auth($count, $registrations_open, $hide_register_button) {
     </section>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="assets/theme.js"></script>
 </body>
 </html>

--- a/modules/home.php
+++ b/modules/home.php
@@ -19,7 +19,7 @@ if($role === 'Normal Personel'):
   </div>
   <div class="nav-right">
     <button id="settingsBtn" aria-label="Ayarlar" role="button"><i class="fa-solid fa-gear"></i></button>
-    <button id="themeToggle" aria-label="Tema" role="button">🌙</button>
+    <button id="themeToggleGlobal" aria-label="Tema" role="button">🌙</button>
     <a href="pages/logout.php" class="logout-btn" aria-label="Çıkış" role="button"><i class="fa-solid fa-arrow-right-from-bracket"></i> Çıkış</a>
   </div>
 </nav>
@@ -83,19 +83,9 @@ if($role === 'Normal Personel'):
   </section>
 </div>
 <script>
-  document.querySelectorAll('.dashboard-card').forEach(function(el){el.addEventListener('click',function(){console.log(el.id);});});
-  const btn=document.getElementById('themeToggle');
-  if(btn){
-    const st=localStorage.getItem('theme')||'dark';
-    if(st==='light') document.body.classList.add('light');
-    btn.textContent=st==='light'?'☀️':'🌙';
-    btn.addEventListener('click',function(){
-      document.body.classList.toggle('light');
-      const now=document.body.classList.contains('light')?'light':'dark';
-      btn.textContent=now==='light'?'☀️':'🌙';
-      localStorage.setItem('theme',now);
-    });
-  }
+  document.querySelectorAll('.dashboard-card').forEach(function(el){
+    el.addEventListener('click',function(){console.log(el.id);});
+  });
 </script>
 <?php
 else:


### PR DESCRIPTION
## Summary
- support light/dark theme with a reusable JS script
- style Bootstrap elements for dark mode
- add theme toggle button on the homepage
- use new global toggle inside the dashboard module

## Testing
- `php -l index.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6841a5d0862083309b0dde5a28e04bf8