### PR TITLE
Add styled settings dropdown

### DIFF
--- a/assets/user-dropdown.css
+++ b/assets/user-dropdown.css
@@ -1,10 +1,16 @@
 .drop-down{display:inline-block;position:relative;}
-.drop-down__button{background:linear-gradient(to right,#3d6def,#8FADFE);color:#fff;border-radius:4px;padding:6px 12px;cursor:pointer;display:flex;align-items:center;}
-.drop-down__icon{width:18px;height:18px;fill:#fff;}
+.drop-down__button{background:linear-gradient(to right,#3d6def,#8FADFE);color:#fff;border-radius:4px;line-height:40px;padding:0 18px;cursor:pointer;display:inline-flex;align-items:center;box-shadow:0 4px 6px rgba(0,0,0,0.2);}
+.drop-down__name{font-size:9px;text-transform:uppercase;color:#fff;font-weight:800;letter-spacing:2px;}
+.drop-down__icon{width:18px;height:18px;fill:#fff;margin-left:14px;transition:all .4s;}
+.drop-down--active .drop-down__icon{transform:rotate(180deg);}
 .drop-down__menu-box{position:absolute;left:0;top:100%;width:100%;background:#fff;border-radius:4px;box-shadow:0 3px 6px rgba(0,0,0,0.2);margin-top:5px;visibility:hidden;opacity:0;transition:all .3s;z-index:1000;}
-.drop-down--active .drop-down__menu-box{visibility:visible;opacity:1;margin-top:10px;}
+.drop-down--active .drop-down__menu-box{visibility:visible;opacity:1;margin-top:15px;}
 .drop-down__menu{list-style:none;margin:0;padding:0;}
-.drop-down__item{font-size:13px;padding:8px 12px;border-bottom:1px solid #e0e2e9;color:#909dc2;}
+.drop-down__item{font-size:13px;padding:13px 0;text-align:left;font-weight:500;color:#909dc2;cursor:pointer;position:relative;border-bottom:1px solid #e0e2e9;}
+.drop-down__item-icon{position:absolute;right:0;font-size:15px;color:#8995b6;}
 .drop-down__item:last-of-type{border-bottom:0;}
 .drop-down__item:hover{color:#3d6def;}
+.drop-down__item:hover .drop-down__item-icon{color:#3d6def;}
+.drop-down__item:before{content:'';position:absolute;width:3px;height:28px;background-color:#3d6def;left:-13px;top:50%;transform:translateY(-50%);display:none;}
+.drop-down__item:hover:before{display:block;}
 .drop-down__item a{text-decoration:none;color:inherit;display:block;}

--- a/index.php
+++ b/index.php
@@ -42,15 +42,18 @@ function render_auth($count, $registrations_open, $hide_register_button) {
     if (isset($_SESSION['user'])) {
         echo "<span class='navbar-text me-2'>Merhaba " . htmlspecialchars($_SESSION['user']) . "</span>";
         echo "<div class='drop-down me-2'>";
-        echo "  <div id='dropDown' class='drop-down__button'><i class='fa-solid fa-gear'></i></div>";
+        echo "  <div id='dropDown' class='drop-down__button'>";
+        echo "    <span class='drop-down__name'>Ayarlar</span>";
+        echo "    <i class='fa-solid fa-gear drop-down__icon'></i>";
+        echo "  </div>";
         echo "  <div class='drop-down__menu-box'>";
         echo "    <ul class='drop-down__menu'>";
-        echo "      <li class='drop-down__item'><a href='pages/profile.php'>Profil</a></li>";
+        echo "      <li class='drop-down__item'><a href='pages/profile.php'>Profil <i class='fa-solid fa-user drop-down__item-icon'></i></a></li>";
         $msg = 'Mesajlar';
         if ($count > 0) { $msg .= " <span class=\'badge bg-danger\'>$count</span>"; }
-        echo "      <li class='drop-down__item'><a href='pages/messages.php'>$msg</a></li>";
+        echo "      <li class='drop-down__item'><a href='pages/messages.php'>$msg <i class='fa-solid fa-envelope drop-down__item-icon'></i></a></li>";
         if ($_SESSION['role'] == 'admin') {
-            echo "      <li class='drop-down__item'><a href='pages/admin.php'>Admin Paneli</a></li>";
+            echo "      <li class='drop-down__item'><a href='pages/admin.php'>Admin Paneli <i class='fa-solid fa-toolbox drop-down__item-icon'></i></a></li>";
         }
         echo "    </ul>";
         echo "  </div>";


### PR DESCRIPTION
## Summary
- style dropdown menu similarly to design example
- show profile, messages and optionally admin panel links with icons

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841ac5d4af08330b5294532c1e75a52