### PR TITLE
Fix announcements table definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ CREATE TABLE messages (
 CREATE TABLE announcements (
     id INT AUTO_INCREMENT PRIMARY KEY,
     content TEXT NOT NULL,
-    publish_date DATE NOT NULL DEFAULT CURRENT_DATE
+    publish_date DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE settings (

--- a/modules/home.php
+++ b/modules/home.php
@@ -10,7 +10,7 @@ if(isset($_SESSION['user'])){
 }
 $theme = get_role_theme($pdo, $role);
 if($theme === 'dashboard'):
-    $pdo->exec("CREATE TABLE IF NOT EXISTS announcements (id INT AUTO_INCREMENT PRIMARY KEY, content TEXT NOT NULL, publish_date DATE NOT NULL DEFAULT CURRENT_DATE)");
+    $pdo->exec("CREATE TABLE IF NOT EXISTS announcements (id INT AUTO_INCREMENT PRIMARY KEY, content TEXT NOT NULL, publish_date DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP)");
     $announcements = $pdo->query('SELECT content, publish_date FROM announcements ORDER BY publish_date DESC')->fetchAll();
 ?>
 <nav class="portal-nav">

--- a/pages/admin.php
+++ b/pages/admin.php
@@ -9,7 +9,7 @@ require __DIR__ . '/../includes/db.php';
 require __DIR__ . '/../includes/activity.php';
 require __DIR__ . '/../includes/settings.php';
 update_activity($pdo);
-$pdo->exec("CREATE TABLE IF NOT EXISTS announcements (id INT AUTO_INCREMENT PRIMARY KEY, content TEXT NOT NULL, publish_date DATE NOT NULL DEFAULT CURRENT_DATE)");
+$pdo->exec("CREATE TABLE IF NOT EXISTS announcements (id INT AUTO_INCREMENT PRIMARY KEY, content TEXT NOT NULL, publish_date DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP)");
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $section = $_POST['section'] ?? '';


### PR DESCRIPTION
## Summary
- define `publish_date` using `DATETIME` with `CURRENT_TIMESTAMP`
- update README example

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841c093989c8330853fa0a998846821