### PR TITLE
Use dynamic site name in dashboard

### DIFF
--- a/modules/home.php
+++ b/modules/home.php
@@ -16,7 +16,7 @@ if($theme === 'dashboard'):
 <nav class="portal-nav">
 <script>document.body.classList.add('home-dashboard');</script>
   <div class="nav-left">
-    <div class="portal-logo">ACIBADEM PORTAL</div>
+    <div class="portal-logo"><?php echo htmlspecialchars($site_name); ?></div>
     <div class="welcome">Hoşgeldiniz, <?php echo htmlspecialchars($full); ?></div>
     <span class="role-pill"><?php echo htmlspecialchars($role); ?></span>
   </div>


### PR DESCRIPTION
## Summary
- replace hardcoded `ACIBADEM PORTAL` label in dashboard navigation with admin configurable site name

## Testing
- `php -l modules/home.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c2dedc188330b766a9545d00ca6f