### PR TITLE
Enable announcement modal on dashboard

### DIFF
--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -69,7 +69,7 @@ body.home-dashboard::before{
 .badge-orange{background:linear-gradient(90deg,#ff9a28,#ff7a00);}
 .announcements{max-width:1000px;margin:24px auto;padding:24px;}
 .announcements h3{font-size:20px;margin-bottom:16px;color:#fff;}
-.announcement-item{border-bottom:1px solid rgba(255,255,255,0.1);padding:8px 0;}
+.announcement-item{border-bottom:1px solid rgba(255,255,255,0.1);padding:8px 0;cursor:pointer;}
 .announcement-item:last-child{border-bottom:none;}
 .announcement-item .title{font-weight:700;font-size:16px;display:block;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%;}
 .announcement-item .date{font-size:12px;color:#9fa6b2;}

--- a/modules/home.php
+++ b/modules/home.php
@@ -118,22 +118,23 @@ if($theme === 'dashboard'):
   </div>
 </div>
 <script>
-  document.querySelectorAll('.dashboard-card').forEach(function(el){
-    el.addEventListener('click',function(){console.log(el.id);});
-  });
-  var annModalEl = document.getElementById('announcementModal');
-  var annModal;
-  if (annModalEl) {
-    annModal = new bootstrap.Modal(annModalEl);
-    document.querySelectorAll('.announcement-item').forEach(function(item){
-      item.addEventListener('click',function(){
-        document.querySelector('#announcementModal .modal-body').innerText = this.getAttribute('data-content');
-        var date = this.getAttribute('data-date');
-        document.querySelector('#announcementModal .modal-title').innerText = 'Duyuru - ' + date;
-        annModal.show();
-      });
+  document.addEventListener('DOMContentLoaded', function(){
+    document.querySelectorAll('.dashboard-card').forEach(function(el){
+      el.addEventListener('click',function(){console.log(el.id);});
     });
-  }
+    var annModalEl = document.getElementById('announcementModal');
+    if (annModalEl) {
+      var annModal = new bootstrap.Modal(annModalEl);
+      document.querySelectorAll('.announcement-item').forEach(function(item){
+        item.addEventListener('click',function(){
+          document.querySelector('#announcementModal .modal-body').innerText = this.getAttribute('data-content');
+          var date = this.getAttribute('data-date');
+          document.querySelector('#announcementModal .modal-title').innerText = 'Duyuru - ' + date;
+          annModal.show();
+        });
+      });
+    }
+  });
 </script>
 <?php
 else:


### PR DESCRIPTION
## Summary
- trigger announcement modal after DOM load so Bootstrap is available
- make dashboard announcements appear clickable

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841c4ef0de083308f5d1f1dd44e1fc7