### PR TITLE
Fix dark theme announcement modal

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -56,3 +56,16 @@ body.light .navbar {
 body.dark a {
   color: #86b7fe;
 }
+
+/* Dark theme overrides for Bootstrap modal */
+body.dark .modal-content {
+  background-color: #1e1e1e;
+  color: #f8f9fa;
+}
+body.dark .modal-header,
+body.dark .modal-footer {
+  border-color: #333;
+}
+body.dark .btn-close {
+  filter: invert(1);
+}


### PR DESCRIPTION
## Summary
- tweak styling for Bootstrap modals when dark mode is active

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841c5f38e788330b5b113b110110ad3