### PR TITLE
Fix light mode text visibility on dashboard

### DIFF
--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -92,6 +92,9 @@ body.home-dashboard::before{
   border:1px solid rgba(0,0,0,0.1);
   color:#212529;
 }
+.home-dashboard.light .dashboard-card p{
+  color:#495057;
+}
 .home-dashboard.light .announcement-item{border-bottom:1px solid rgba(0,0,0,0.1);}
 .home-dashboard.light .announcement-item .date{color:#6c757d;}
 .home-dashboard.light .nav-right button,.home-dashboard.light .nav-right a{color:#212529;}


### PR DESCRIPTION
## Summary
- ensure dashboard card text is readable in light mode

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841cb5d72cc83309f02d9c023b536a6