### PR TITLE
Update shift module name and dashboard link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a simple PHP-based web portal designed for corporate healthcare personnel. User information is stored in a MySQL database rather than `users.json`.
 
-- **Shift Management** (`shift.php`)
+- **Çalışma Listesi** (`shift.php`)
 - **Trainings** (`training.php`)
 - **Exams** (`exam.php`)
 - **Procedure Documents** (`procedure.php`)
@@ -117,7 +117,7 @@ INSERT INTO settings (name, value) VALUES
 
 -- Example initial modules
 INSERT INTO modules (name, file) VALUES
-    ('Vardiya Sistemi','shift'),
+    ('Çalışma Listesi','shift'),
     ('Eğitimler','training'),
     ('Sınavlar','exam'),
     ('Prosedürler','procedure');

--- a/modules/home.php
+++ b/modules/home.php
@@ -120,7 +120,11 @@ if($theme === 'dashboard'):
 <script>
   document.addEventListener('DOMContentLoaded', function(){
     document.querySelectorAll('.dashboard-card').forEach(function(el){
-      el.addEventListener('click',function(){console.log(el.id);});
+      el.addEventListener('click', function(){
+        if (el.id === 'work-list') {
+          window.location.href = 'index.php?module=shift';
+        }
+      });
     });
     var annModalEl = document.getElementById('announcementModal');
     if (annModalEl) {

--- a/modules/shift.php
+++ b/modules/shift.php
@@ -3,7 +3,7 @@ require_once __DIR__ . '/../includes/db.php';
 $stmt = $pdo->query('SELECT date, time FROM shifts ORDER BY date');
 $shifts = $stmt->fetchAll();
 ?>
-<h2 class="mb-3">Vardiya Sistemi</h2>
+<h2 class="mb-3">Çalışma Listesi</h2>
 <table class="table table-striped">
     <tr><th>Tarih</th><th>Vardiya</th></tr>
     <?php foreach ($shifts as $s): ?>

--- a/pages/admin.php
+++ b/pages/admin.php
@@ -192,7 +192,7 @@ foreach($roles as $r){
                 <button class="nav-link active" id="users-tab" data-bs-toggle="tab" data-bs-target="#users" type="button" role="tab">Kullanıcılar</button>
             </li>
             <li class="nav-item" role="presentation">
-                <button class="nav-link" id="shifts-tab" data-bs-toggle="tab" data-bs-target="#shifts" type="button" role="tab">Vardiyalar</button>
+                <button class="nav-link" id="shifts-tab" data-bs-toggle="tab" data-bs-target="#shifts" type="button" role="tab">Çalışma Listesi</button>
             </li>
             <li class="nav-item" role="presentation">
                 <button class="nav-link" id="trainings-tab" data-bs-toggle="tab" data-bs-target="#trainings" type="button" role="tab">Eğitimler</button>


### PR DESCRIPTION
## Summary
- rename shift module to **Çalışma Listesi**
- point dashboard "Çalışma Listesi" card to the shift module
- update admin tab label
- document new name in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841cda0739083308b7f670e95f2cd15