### PR TITLE
Fix work list site name

### DIFF
--- a/modules/shift.php
+++ b/modules/shift.php
@@ -1,5 +1,7 @@
 <?php
-$server = $_SERVER['SERVER_NAME'] ?? 'SUNUCU';
+// Display the site name configured in the admin panel if available.
+// Fallback to the server hostname when the setting is not defined.
+$server = $site_name ?? ($_SERVER['SERVER_NAME'] ?? 'SUNUCU');
 ?>
 <script>document.body.classList.add('worklist-page');</script>
 <link rel="stylesheet" href="assets/worklist.css">


### PR DESCRIPTION
## Summary
- show configured site name instead of hostname in Shift module

## Testing
- `php -l modules/shift.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d625bf4c8330b226fc71bd7e1dfe