### PR TITLE
Add header nav links for shift module

### DIFF
--- a/assets/worklist.css
+++ b/assets/worklist.css
@@ -34,8 +34,27 @@ body.worklist-page section.card {
   backdrop-filter: blur(6px);
   box-shadow: 0 2px 4px rgba(0,0,0,0.4);
 }
-.wl-header .left { font-weight: 700; font-size: 18px; }
-.wl-header .home-link { color: #3fa7ff; text-decoration: none; font-weight: 500; }
+.wl-header .left {
+  font-weight: 700;
+  font-size: 18px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.wl-header .wl-nav {
+  display: flex;
+}
+.wl-header .wl-nav .nav-link {
+  color: #3fa7ff;
+  text-decoration: none;
+  font-weight: 500;
+  margin-left: 12px;
+}
+.wl-header .home-link {
+  color: #3fa7ff;
+  text-decoration: none;
+  font-weight: 500;
+}
 
 .wl-container { display: flex; flex: 1; overflow: hidden; }
 

--- a/modules/shift.php
+++ b/modules/shift.php
@@ -16,8 +16,14 @@ function tr_upper(string $text): string {
 <link rel="stylesheet" href="assets/worklist.css">
 <div id="wls-app">
   <header class="wl-header">
-    <div class="left"><?php echo tr_upper($server); ?> | ÇALIŞMA LİSTESİ & İSTEKLER</div>
-    <div class="right"><a class="home-link" href="index.php">Ana Sayfa</a></div>
+    <div class="left">
+      <span class="site-name"><?php echo tr_upper($server); ?> | ÇALIŞMA LİSTESİ & İSTEKLER</span>
+      <nav class="wl-nav">
+        <a href="index.php" class="nav-link">Ana Sayfa</a>
+        <a href="pages/users.php" class="nav-link">Kullanıcılar</a>
+      </nav>
+    </div>
+    <div class="right"><a class="home-link" href="#">İstekte Bulun</a></div>
   </header>
   <div class="wl-container">
     <aside class="wl-sidebar">


### PR DESCRIPTION
## Summary
- update the shift page header to show `Ana Sayfa` and `Kullanıcılar` links
- rename header action link to `İstekte Bulun`
- adjust worklist stylesheet for the new header layout

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841ec50a0688330a6ee694db6e309c8