### PR TITLE
Move shift nav links to main header

### DIFF
--- a/assets/worklist.css
+++ b/assets/worklist.css
@@ -41,15 +41,6 @@ body.worklist-page section.card {
   align-items: center;
   gap: 12px;
 }
-.wl-header .wl-nav {
-  display: flex;
-}
-.wl-header .wl-nav .nav-link {
-  color: #3fa7ff;
-  text-decoration: none;
-  font-weight: 500;
-  margin-left: 12px;
-}
 .wl-header .home-link {
   color: #3fa7ff;
   text-decoration: none;

--- a/index.php
+++ b/index.php
@@ -87,7 +87,17 @@ function render_auth($count, $registrations_open, $hide_register_button) {
 <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
         <div class="container">
+            <?php if($module === 'shift'): ?>
+            <div class="d-flex align-items-center gap-3">
+                <a class="navbar-brand" href="index.php"><?php echo htmlspecialchars($site_name); ?></a>
+                <div class="d-none d-md-flex">
+                    <a href="index.php" class="nav-link text-white">Ana Sayfa</a>
+                    <a href="pages/users.php" class="nav-link text-white ms-2">Kullanıcılar</a>
+                </div>
+            </div>
+            <?php else: ?>
             <a class="navbar-brand" href="index.php"><?php echo htmlspecialchars($site_name); ?></a>
+            <?php endif; ?>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/modules/shift.php
+++ b/modules/shift.php
@@ -18,10 +18,6 @@ function tr_upper(string $text): string {
   <header class="wl-header">
     <div class="left">
       <span class="site-name"><?php echo tr_upper($server); ?> | ÇALIŞMA LİSTESİ & İSTEKLER</span>
-      <nav class="wl-nav">
-        <a href="index.php" class="nav-link">Ana Sayfa</a>
-        <a href="pages/users.php" class="nav-link">Kullanıcılar</a>
-      </nav>
     </div>
     <div class="right"><a class="home-link" href="#">İstekte Bulun</a></div>
   </header>


### PR DESCRIPTION
## Summary
- move links from shift module header into the main navbar
- clean up unused shift nav styling

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842e6cc7304833093ebe87017378a07