### PR TITLE
Enhance messages UI for dark mode

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -17,6 +17,7 @@ body {
 .bubble.mine {background:#d0ebff; margin-left:auto;}
 .bubble.theirs {background:#f1f3f5; margin-right:auto;}
 .bubble .meta {font-size:0.75rem; color:#6c757d; text-align:right;}
+body.dark .bubble .meta {color:#adb5bd;}
 .bubble .sender{font-size:0.75rem;font-weight:500;color:#dc3545;margin-bottom:2px;}
 .bubble .status {margin-left:4px; animation:fadein 0.3s;}
 #onlineDot{width:12px;height:12px;bottom:0;right:0;transform:translate(50%,50%);}
@@ -78,4 +79,36 @@ body.dark .btn-close {
 #announcements .list-group-item span {
   flex: 1 1 100%;
   word-break: break-word;
+}
+
+/* Dark theme adjustments for messaging */
+body.dark #chatBox {
+  background-color: #1e1e1e;
+  border-color: #333;
+}
+body.dark .chat-header {
+  background-color: #1f1f1f;
+  border-color: #333;
+}
+body.dark .bubble {
+  background: #2a2a2a;
+  color: #f8f9fa;
+}
+body.dark .bubble.mine {
+  background: #0d6efd;
+}
+body.dark .bubble.theirs {
+  background: #343a40;
+}
+body.dark .admin-msg {
+  background: #663c40;
+}
+body.dark .list-group-item {
+  background-color: #1e1e1e;
+  color: #f8f9fa;
+  border-color: #333;
+}
+body.dark .list-group-item.active {
+  background-color: #0d6efd;
+  border-color: #0d6efd;
 }

--- a/pages/messages.php
+++ b/pages/messages.php
@@ -53,7 +53,10 @@ $allUsers = $userStmt->fetchAll();
 </head>
 <body>
 <div class="container my-4">
-    <h2 class="mb-3">Mesajlar</h2>
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h2 class="mb-0">Mesajlar</h2>
+        <button id="themeToggleGlobal" class="btn btn-outline-secondary btn-sm" type="button">🌙</button>
+    </div>
     <div class="row">
         <div id="usersCol" class="col-md-4">
             <h5>Kullanıcılar</h5>


### PR DESCRIPTION
## Summary
- add dark theme UI for the messaging page
- include theme toggle button on messages page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684319e2776083308b78d7e76f285daa