### PR TITLE
Fix dark mode for messaging page

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -57,6 +57,36 @@ body.dark a {
   color: #86b7fe;
 }
 
+/* Dark theme adjustments for messaging */
+body.dark .text-dark {
+  color: #f8f9fa !important;
+}
+body.dark .chat-header {
+  background-color: #1e1e1e;
+  border-color: #333;
+}
+body.dark #chatBox {
+  background-color: #1e1e1e;
+}
+body.dark .bubble {
+  background-color: #343a40;
+  color: #fff;
+}
+body.dark .bubble.mine {
+  background-color: #0d6efd;
+}
+body.dark .bubble .meta {
+  color: #adb5bd;
+}
+body.dark .list-group-item {
+  background-color: #1e1e1e;
+  color: #f8f9fa;
+}
+body.dark .list-group-item.active {
+  background-color: #0d6efd;
+  border-color: #0d6efd;
+}
+
 /* Dark theme overrides for Bootstrap modal */
 body.dark .modal-content {
   background-color: #1e1e1e;

--- a/pages/messages.php
+++ b/pages/messages.php
@@ -93,7 +93,7 @@ $allUsers = $userStmt->fetchAll();
                     $avatar = $prof['picture'] ? 'uploads/'.htmlspecialchars($prof['picture']) : 'https://via.placeholder.com/40x40?text='.urlencode(mb_substr($fullName,0,1));
                 ?>
                 <div id="chatHeader" class="chat-header d-flex align-items-center p-2 border-bottom">
-                    <a href="view_profile.php?user=<?php echo urlencode($targetUser); ?>" class="d-flex align-items-center text-decoration-none text-dark">
+                    <a href="view_profile.php?user=<?php echo urlencode($targetUser); ?>" class="d-flex align-items-center text-decoration-none">
                         <div class="position-relative me-2">
                             <img src="<?php echo $avatar; ?>" class="rounded-circle" width="40" height="40" alt="avatar">
                             <span id="onlineDot" class="position-absolute bg-success border border-light rounded-circle d-none"></span>


### PR DESCRIPTION
## Summary
- improve dark mode styles for messaging
- remove hardcoded text-dark class from chat header link

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68431b885e508330bdf0138ddbfed82b