### PR TITLE
Fix messaging dark mode text

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -56,6 +56,9 @@ body.light .navbar {
 body.dark a {
   color: #86b7fe;
 }
+body.dark .text-muted {
+  color: #adb5bd !important;
+}
 
 /* Dark theme adjustments for messaging */
 body.dark .text-dark {


### PR DESCRIPTION
## Summary
- adjust text-muted color for dark mode so last seen and dates are readable

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68431e4341208330a815c039c8da71a4