### PR TITLE
Fix double check visibility in dark theme

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -81,6 +81,9 @@ body.dark .bubble.mine {
 body.dark .bubble .meta {
   color: #adb5bd;
 }
+body.dark .bubble .status {
+  color: #f8f9fa;
+}
 body.dark .list-group-item {
   background-color: #1e1e1e;
   color: #f8f9fa;


### PR DESCRIPTION
## Summary
- update CSS for `body.dark` messaging bubbles so delivery checkmarks remain visible

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68432d6a69748330a056372c3050185d