### PR TITLE
Fix visibility of delivered icon in dark mode

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -84,6 +84,9 @@ body.dark .bubble .meta {
 body.dark .bubble .status {
   color: #f8f9fa;
 }
+body.dark .bubble.mine .status span {
+  color: #fff !important;
+}
 body.dark .list-group-item {
   background-color: #1e1e1e;
   color: #f8f9fa;


### PR DESCRIPTION
## Summary
- tweak CSS for message status in dark theme so the check marks remain visible

## Testing
- `npm test` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684333cfaac48330a535eedb0543e579