### PR TITLE
Update footer text for Shift module

### DIFF
--- a/assets/worklist.css
+++ b/assets/worklist.css
@@ -61,7 +61,7 @@ body.worklist-page section.card {
 .wl-sidebar li i { margin-right:10px; width:20px; text-align:center; }
 .wl-sidebar li.active { border-left:4px solid #3fa7ff; background: rgba(255,255,255,0.05); font-weight:700; }
 .wl-sidebar li:hover { background: rgba(255,255,255,0.1); }
-.wl-sidebar .sidebar-footer { padding:12px 16px; font-size:12px; opacity:0.6; }
+.wl-sidebar .sidebar-footer { padding:12px 16px; font-size:12px; opacity:0.6; text-align:center; }
 
 .wl-main { flex:1; overflow-y:auto; padding:24px; }
 

--- a/modules/shift.php
+++ b/modules/shift.php
@@ -24,7 +24,7 @@ function tr_upper(string $text): string {
         <li data-view="requests"><i class="fa-solid fa-list"></i><span>İsteklerim</span></li>
         <li data-view="stats"><i class="fa-solid fa-chart-column"></i><span>Vardiya İstatistikleri</span></li>
       </ul>
-      <div class="sidebar-footer">Modül v2.5</div>
+      <div class="sidebar-footer"><?php echo htmlspecialchars($server); ?></div>
     </aside>
     <main class="wl-main">
       <div id="weekly" class="wl-view active"><div class="wl-card">Haftalık Liste Henüz Uygulanmadı.</div></div>


### PR DESCRIPTION
## Summary
- replace hard-coded footer in the shift module with the configured site name
- center align footer text in worklist sidebar

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684336073a908330b7080313fe298690