### PR TITLE
Implement basic password reset flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ CREATE TABLE announcements (
     publish_date DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
+CREATE TABLE password_resets (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    token VARCHAR(255) NOT NULL,
+    expires_at DATETIME NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
 CREATE TABLE settings (
     name VARCHAR(50) PRIMARY KEY,
     value VARCHAR(50) NOT NULL

--- a/includes/password_reset.php
+++ b/includes/password_reset.php
@@ -1,0 +1,35 @@
+<?php
+function create_reset_token(PDO $pdo, int $userId): string {
+    $pdo->exec("CREATE TABLE IF NOT EXISTS password_resets (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        user_id INT NOT NULL,
+        token VARCHAR(255) NOT NULL,
+        expires_at DATETIME NOT NULL,
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    )");
+    $token = bin2hex(random_bytes(16));
+    $expiry = date('Y-m-d H:i:s', time() + 3600); // 1 hour
+    $stmt = $pdo->prepare('INSERT INTO password_resets (user_id, token, expires_at) VALUES (?,?,?)');
+    $stmt->execute([$userId, $token, $expiry]);
+    return $token;
+}
+
+function get_user_id_by_token(PDO $pdo, string $token): ?int {
+    $pdo->prepare('DELETE FROM password_resets WHERE expires_at < NOW()')->execute();
+    $stmt = $pdo->prepare('SELECT user_id FROM password_resets WHERE token=? AND expires_at >= NOW()');
+    $stmt->execute([$token]);
+    $uid = $stmt->fetchColumn();
+    return $uid !== false ? (int)$uid : null;
+}
+
+function invalidate_token(PDO $pdo, string $token): void {
+    $stmt = $pdo->prepare('DELETE FROM password_resets WHERE token=?');
+    $stmt->execute([$token]);
+}
+
+function update_user_password(PDO $pdo, int $userId, string $password): void {
+    $hash = password_hash($password, PASSWORD_DEFAULT);
+    $stmt = $pdo->prepare('UPDATE users SET password=? WHERE id=?');
+    $stmt->execute([$hash, $userId]);
+}
+?>

--- a/pages/forgot_password.php
+++ b/pages/forgot_password.php
@@ -1,0 +1,56 @@
+<?php
+session_start();
+require __DIR__ . '/../includes/db.php';
+require __DIR__ . '/../includes/password_reset.php';
+
+$message = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $identifier = trim($_POST['identifier'] ?? '');
+    if ($identifier !== '') {
+        $stmt = $pdo->prepare('SELECT id, username FROM users WHERE username = ?');
+        $stmt->execute([$identifier]);
+        $user = $stmt->fetch();
+        if ($user) {
+            $token = create_reset_token($pdo, $user['id']);
+            $link = sprintf('http://%s%s?token=%s', $_SERVER['HTTP_HOST'], dirname($_SERVER['PHP_SELF']) . '/reset_password.php', $token);
+            // assume username is an email
+            @mail($user['username'], 'Password Reset', "Şifre sıfırlama bağlantınız: $link");
+        }
+        $message = 'Eğer hesap mevcutsa, e-posta ile bir bağlantı gönderildi.';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Şifre Sıfırla</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="../assets/login.css">
+</head>
+<body>
+<div class="ring">
+    <i style="--clr:#00ff0a;"></i>
+    <i style="--clr:#ff0057;"></i>
+    <i style="--clr:#fffd44;"></i>
+    <div class="login">
+        <h2>Şifre Sıfırlama</h2>
+        <?php if ($message) echo "<div class='alert alert-info'>$message</div>"; ?>
+        <form method="post">
+            <div class="inputBx">
+                <input type="text" name="identifier" placeholder="Kullanıcı Adı veya E-posta" required>
+            </div>
+            <div class="inputBx">
+                <input type="submit" value="Gönder">
+            </div>
+            <div class="links">
+                <a href="login.php">Giriş Yap</a>
+            </div>
+        </form>
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="../assets/theme.js"></script>
+</body>
+</html>

--- a/pages/login.php
+++ b/pages/login.php
@@ -53,7 +53,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     <input type="submit" value="Giriş Yap">
                 </div>
                 <div class="links">
-                    <a href="#">Şifremi Unuttum</a>
+                    <a href="forgot_password.php">Şifremi Unuttum</a>
                     <?php if ($registrations_open == '1' && $hide_register_button != '1'): ?>
                     <a href="register.php">Kayıt Ol</a>
                     <?php endif; ?>

--- a/pages/register.php
+++ b/pages/register.php
@@ -64,6 +64,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 </div>
                 <div class="links">
                     <a href="login.php">Giriş Yap</a>
+                    <a href="forgot_password.php">Şifremi Unuttum</a>
                 </div>
             </form>
         </div>

--- a/pages/reset_password.php
+++ b/pages/reset_password.php
@@ -1,0 +1,61 @@
+<?php
+session_start();
+require __DIR__ . '/../includes/db.php';
+require __DIR__ . '/../includes/password_reset.php';
+
+$token = $_GET['token'] ?? '';
+$message = '';
+$success = false;
+$userId = $token ? get_user_id_by_token($pdo, $token) : null;
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $new1 = $_POST['password'] ?? '';
+    $new2 = $_POST['password2'] ?? '';
+    if ($userId && $new1 !== '' && $new1 === $new2) {
+        update_user_password($pdo, $userId, $new1);
+        invalidate_token($pdo, $token);
+        $success = true;
+    } else {
+        $message = 'Geçersiz token veya şifreler uyuşmuyor.';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Şifre Sıfırla</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="../assets/login.css">
+</head>
+<body>
+<div class="ring">
+    <i style="--clr:#00ff0a;"></i>
+    <i style="--clr:#ff0057;"></i>
+    <i style="--clr:#fffd44;"></i>
+    <div class="login">
+        <h2>Yeni Şifre</h2>
+        <?php if ($success): ?>
+            <div class='alert alert-success'>Şifre güncellendi. <a href="login.php">Giriş yap</a>.</div>
+        <?php elseif (!$userId): ?>
+            <div class='alert alert-danger'>Geçersiz veya süresi dolmuş bağlantı.</div>
+        <?php else: ?>
+            <?php if ($message) echo "<div class='alert alert-danger'>$message</div>"; ?>
+            <form method="post">
+                <div class="inputBx">
+                    <input type="password" name="password" placeholder="Yeni Şifre" required>
+                </div>
+                <div class="inputBx">
+                    <input type="password" name="password2" placeholder="Yeni Şifre (Tekrar)" required>
+                </div>
+                <div class="inputBx">
+                    <input type="submit" value="Sıfırla">
+                </div>
+            </form>
+        <?php endif; ?>
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="../assets/theme.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `password_resets` table instructions
- add helper for password resets
- implement `forgot_password.php` and `reset_password.php`
- link forgot password feature from login and register pages

## Testing
- `npm test` *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_6844b5ebb910833094271ba3247d95d6