### PR TITLE
Implement activity logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,15 @@ CREATE TABLE site_pages (
     content TEXT NOT NULL
 );
 
+CREATE TABLE activity_log (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    action VARCHAR(100) NOT NULL,
+    timestamp DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    details TEXT,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
 INSERT INTO settings (name, value) VALUES
     ('registrations_open','1'),
     ('hide_register_button','0'),

--- a/includes/activity.php
+++ b/includes/activity.php
@@ -5,4 +5,25 @@ function update_activity(PDO $pdo){
         $stmt->execute([$_SESSION['user']]);
     }
 }
+
+function log_activity(PDO $pdo, string $action, string $details = ''): void {
+    if(!isset($_SESSION['user'])){
+        return;
+    }
+    $pdo->exec("CREATE TABLE IF NOT EXISTS activity_log (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        user_id INT NOT NULL,
+        action VARCHAR(100) NOT NULL,
+        timestamp DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        details TEXT,
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    )");
+    $stmt = $pdo->prepare('SELECT id FROM users WHERE username=?');
+    $stmt->execute([$_SESSION['user']]);
+    $uid = $stmt->fetchColumn();
+    if($uid){
+        $ins = $pdo->prepare('INSERT INTO activity_log (user_id, action, details) VALUES (?,?,?)');
+        $ins->execute([$uid, $action, $details]);
+    }
+}
 ?>

--- a/pages/activity_log.php
+++ b/pages/activity_log.php
@@ -1,0 +1,75 @@
+<?php
+session_start();
+if (!isset($_SESSION['role']) || $_SESSION['role'] != 'admin') {
+    echo 'Erişim reddedildi';
+    exit;
+}
+require __DIR__ . '/../includes/db.php';
+require __DIR__ . '/../includes/activity.php';
+update_activity($pdo);
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS activity_log (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    action VARCHAR(100) NOT NULL,
+    timestamp DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    details TEXT,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+)");
+
+$user = trim($_GET['user'] ?? '');
+$action = trim($_GET['action'] ?? '');
+$where = [];
+$params = [];
+if ($user !== '') {
+    $where[] = 'u.username = ?';
+    $params[] = $user;
+}
+if ($action !== '') {
+    $where[] = 'l.action LIKE ?';
+    $params[] = $action;
+}
+$sql = "SELECT l.id, u.username, l.action, l.timestamp, l.details FROM activity_log l JOIN users u ON l.user_id=u.id";
+if ($where) {
+    $sql .= ' WHERE ' . implode(' AND ', $where);
+}
+$sql .= ' ORDER BY l.timestamp DESC LIMIT 100';
+$stmt = $pdo->prepare($sql);
+$stmt->execute($params);
+$logs = $stmt->fetchAll();
+?>
+<!DOCTYPE html>
+<html lang='tr'>
+<head>
+    <meta charset='UTF-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Activity Log</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="../assets/style.css">
+</head>
+<body>
+<div class="container my-4">
+    <h2 class="mb-3">Activity Log</h2>
+    <form method="get" class="row g-2 mb-3">
+        <div class="col-md-3"><input type="text" name="user" class="form-control" placeholder="Kullanıcı" value="<?php echo htmlspecialchars($user); ?>"></div>
+        <div class="col-md-3"><input type="text" name="action" class="form-control" placeholder="İşlem" value="<?php echo htmlspecialchars($action); ?>"></div>
+        <div class="col-md-2"><button class="btn btn-primary">Filtrele</button></div>
+    </form>
+    <table class="table table-sm table-striped">
+        <tr><th>ID</th><th>Kullanıcı</th><th>İşlem</th><th>Zaman</th><th>Ayrıntı</th></tr>
+        <?php foreach ($logs as $log): ?>
+            <tr>
+                <td><?php echo $log['id']; ?></td>
+                <td><?php echo htmlspecialchars($log['username']); ?></td>
+                <td><?php echo htmlspecialchars($log['action']); ?></td>
+                <td><?php echo $log['timestamp']; ?></td>
+                <td><?php echo htmlspecialchars($log['details']); ?></td>
+            </tr>
+        <?php endforeach; ?>
+    </table>
+    <a href="admin.php" class="btn btn-secondary">Geri</a>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="../assets/theme.js"></script>
+</body>
+</html>

--- a/pages/admin.php
+++ b/pages/admin.php
@@ -205,6 +205,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 }
             }
         }
+        log_activity($pdo, 'admin_' . $section . '_' . $action);
         if($section==='admin_messages'){
             header('Location: admin.php?u1=' . urlencode($u1) . '&u2=' . urlencode($u2) . '#messages');
         } else {

--- a/pages/login.php
+++ b/pages/login.php
@@ -2,6 +2,7 @@
 session_start();
 require __DIR__ . '/../includes/db.php';
 require __DIR__ . '/../includes/settings.php';
+require __DIR__ . '/../includes/activity.php';
 $registrations_open = get_setting($pdo, 'registrations_open', '1');
 $hide_register_button = get_setting($pdo, 'hide_register_button', '0');
 $error = '';
@@ -16,6 +17,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $_SESSION['role'] = $user['role'];
         $up = $pdo->prepare('UPDATE users SET last_active=NOW() WHERE username=?');
         $up->execute([$user['username']]);
+        log_activity($pdo, 'login');
         header('Location: ../index.php');
         exit;
     } else {

--- a/pages/profile.php
+++ b/pages/profile.php
@@ -43,6 +43,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $stmt = $pdo->prepare('UPDATE users SET password=? WHERE id=?');
                 $stmt->execute([password_hash($new1, PASSWORD_DEFAULT), $userId]);
                 $passMessage = 'Şifre güncellendi';
+                log_activity($pdo, 'profile_password_change');
             }
         }
     } elseif(isset($_POST['add_experience'])){
@@ -52,12 +53,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $stmt = $pdo->prepare('INSERT INTO experiences (user_id, title, exp_date) VALUES (?,?,?)');
             $stmt->execute([$userId,$title,$date]);
             $message = 'Deneyim eklendi';
+            log_activity($pdo, 'profile_add_experience', $title);
         }
     } elseif(isset($_POST['delete_experience'])){
         $id = (int)$_POST['delete_experience'];
         $stmt = $pdo->prepare('DELETE FROM experiences WHERE id=? AND user_id=?');
         $stmt->execute([$id,$userId]);
         $message = 'Deneyim silindi';
+        log_activity($pdo, 'profile_delete_experience', (string)$id);
     } else {
         $full  = $_POST['full_name'] ?? '';
         $dept  = $_POST['department'] ?? '';
@@ -87,6 +90,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmt->execute([$userId, $full, $dept, $phone, $birth, $pic]);
     }
         $message = 'Profil güncellendi';
+        log_activity($pdo, 'profile_update');
     }
 }
 $stmt = $pdo->prepare('SELECT full_name, department, phone, birthdate, picture FROM profiles WHERE user_id = ?');


### PR DESCRIPTION
## Summary
- create `activity_log` table
- add `log_activity` helper
- log login, profile updates and admin changes
- add admin page to view activity

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6844b83c583083309dade44416345aea