### PR TITLE
Improve mobile dashboard header

### DIFF
--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -100,3 +100,10 @@ body.home-dashboard::before{
 .home-dashboard.light .announcement-item .date{color:#6c757d;}
 .home-dashboard.light .nav-right button,.home-dashboard.light .nav-right a{color:#212529;}
 .home-dashboard.light .nav-right a.logout-btn{background:#dc3545;color:#fff;}
+
+@media (max-width:576px){
+  .portal-nav{padding:12px;}
+  .nav-left{flex-direction:row;align-items:center;}
+  .nav-left .welcome,.nav-left .role-pill{display:none;}
+  .nav-right #themeToggleGlobal,.nav-right .logout-btn{display:none;}
+}

--- a/assets/user-dropdown.css
+++ b/assets/user-dropdown.css
@@ -12,7 +12,13 @@
 .drop-down__item-text{flex:1;}
 .drop-down__item:last-of-type{border-bottom:0;}
 .drop-down__item:hover{background:#f8f9fa;}
+
 .drop-down__item a{display:flex;align-items:center;width:100%;text-decoration:none;color:inherit;}
+.menu-btn{background:none;border:none;color:inherit;font:inherit;padding:0;display:flex;align-items:center;width:100%;text-align:left;cursor:pointer;}
+.mobile-only{display:none;}
+@media (max-width:576px){
+  .mobile-only{display:flex;}
+}
 
 /* Dark theme overrides */
 body.dark .drop-down__menu-box{background:#1f1f1f;border-color:#333;}

--- a/modules/home.php
+++ b/modules/home.php
@@ -33,6 +33,8 @@ if($theme === 'dashboard'):
           <?php if($role === 'admin'): ?>
           <li class="drop-down__item"><a href="pages/admin.php"><i class="fa-solid fa-toolbox drop-down__item-icon"></i><span class="drop-down__item-text">Admin Paneli</span></a></li>
           <?php endif; ?>
+          <li class="drop-down__item mobile-only"><button id="themeToggleGlobal" class="menu-btn" aria-label="Tema"><i class="fa-solid fa-moon drop-down__item-icon"></i><span class="drop-down__item-text">Tema</span></button></li>
+          <li class="drop-down__item mobile-only"><a href="pages/logout.php"><i class="fa-solid fa-arrow-right-from-bracket drop-down__item-icon"></i><span class="drop-down__item-text">Çıkış</span></a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- enhance mobile dropdown menu styles
- tweak header layout at small widths
- add mobile-only theme toggle and logout

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6844ca1f551083308ec84a01015e7d72