### PR TITLE
Improve mobile dashboard header

### DIFF
--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -100,3 +100,13 @@ body.home-dashboard::before{
 .home-dashboard.light .announcement-item .date{color:#6c757d;}
 .home-dashboard.light .nav-right button,.home-dashboard.light .nav-right a{color:#212529;}
 .home-dashboard.light .nav-right a.logout-btn{background:#dc3545;color:#fff;}
+
+@media (max-width:576px){
+  .portal-nav{padding:8px 12px;}
+  .portal-logo{font-size:18px;}
+  .nav-left{flex-direction:row;align-items:center;gap:6px;}
+  .nav-left .welcome{display:none;}
+  .nav-right button,.nav-right a{margin-left:8px;padding:4px;font-size:18px;}
+  .nav-right a.logout-btn{padding:4px 8px;}
+  .nav-right .logout-text{display:none;}
+}

--- a/modules/home.php
+++ b/modules/home.php
@@ -37,7 +37,10 @@ if($theme === 'dashboard'):
       </div>
     </div>
     <button id="themeToggleGlobal" aria-label="Tema" role="button">🌙</button>
-    <a href="pages/logout.php" class="logout-btn" aria-label="Çıkış" role="button"><i class="fa-solid fa-arrow-right-from-bracket"></i> Çıkış</a>
+    <a href="pages/logout.php" class="logout-btn" aria-label="Çıkış" role="button">
+      <i class="fa-solid fa-arrow-right-from-bracket"></i>
+      <span class="logout-text"> Çıkış</span>
+    </a>
   </div>
 </nav>
 <div class="dashboard">


### PR DESCRIPTION
## Summary
- tweak header logout button markup for mobile-friendly text hiding
- add mobile styles for dashboard header

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6844cd2df7fc83308f3db095906f5d32