### PR TITLE
Modernize mobile dashboard header

### DIFF
--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -1,13 +1,23 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
 :root{
+  --bg:#0e1b2b;
+  --fg:#fff;
   --accent:#0dd4a3;
+}
+body.light{
+  --bg:#ffffff;
+  --fg:#212529;
+}
+body.dark{
+  --bg:#1f1f1f;
+  --fg:#f8f9fa;
 }
 body.home-dashboard{
   font-family:'Inter',sans-serif;
   font-size:15px;
   line-height:1.5;
-  color:#fff;
-  background:linear-gradient(180deg,#0e1b2b,#142438);
+  color:var(--fg);
+  background:linear-gradient(180deg,var(--bg),#142438);
   min-height:100vh;
   position:relative;
 }
@@ -20,25 +30,40 @@ body.home-dashboard::before{
   pointer-events:none;
   z-index:0;
 }
-.portal-nav{
+.dash-header{
   display:flex;
   justify-content:space-between;
   align-items:center;
-  padding:12px 24px;
-  position:fixed;
+  padding:0 16px;
+  height:64px;
+  position:sticky;
   top:0;left:0;right:0;
-  background:rgba(14,27,43,0.8);
-  backdrop-filter:blur(6px);
-  box-shadow:0 2px 4px rgba(0,0,0,0.4);
-  z-index:10;
+  background:var(--bg);
+  color:var(--fg);
+  transition:transform .3s, background .3s;
+  z-index:1000;
 }
-.portal-logo{font-size:24px;font-weight:700;text-transform:uppercase;}
-.nav-left{display:flex;flex-direction:column;line-height:1.2;}
-.nav-left .welcome{font-size:14px;margin-top:2px;}
-.role-pill{background:rgba(255,255,255,0.15);padding:2px 8px;border-radius:9999px;font-size:12px;margin-top:2px;display:inline-block;}
-.nav-right button,.nav-right a{background:none;border:none;color:#fff;margin-left:12px;font-size:16px;cursor:pointer;border-radius:8px;padding:6px;}
-.nav-right a.logout-btn{background:#ff3b3b;padding:6px 12px;}
-.nav-right button:hover,.nav-right a:hover{filter:brightness(1.2);}
+.dash-header.hide{transform:translateY(-100%);}
+.site-info{display:flex;flex-direction:column;line-height:1.2;}
+.site-name{font-size:20px;font-weight:600;}
+.welcome{font-size:13px;}
+@media (max-width:360px){
+  .dash-header .welcome{display:none;}
+}
+.quick-actions{display:flex;align-items:center;gap:8px;}
+.icon-btn{background:none;border:none;color:inherit;padding:4px;cursor:pointer;font-size:22px;display:flex;align-items:center;}
+.icon-btn .badge{background:#dc3545;color:#fff;border-radius:9999px;font-size:10px;min-width:16px;height:16px;display:flex;align-items:center;justify-content:center;margin-left:2px;}
+.avatar-btn{width:32px;height:32px;border-radius:50%;background:var(--accent);color:#fff;font-weight:600;display:flex;align-items:center;justify-content:center;font-size:16px;border:none;cursor:pointer;}
+.settings-menu{position:fixed;inset:0;background:var(--bg);color:var(--fg);transform:translateX(100%);transition:transform .3s;z-index:9999;padding:16px;display:flex;flex-direction:column;}
+.settings-menu.open{transform:translateX(0);}
+.menu-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:16px;}
+.menu-title{font-size:20px;font-weight:600;}
+.close-btn{background:none;border:none;color:inherit;font-size:24px;cursor:pointer;}
+.menu-welcome{font-size:14px;margin-bottom:8px;}
+.menu-list{list-style:none;margin:0;padding:0;}
+.menu-list li a{display:flex;align-items:center;gap:12px;height:48px;text-decoration:none;color:inherit;padding:0 8px;font-size:16px;border-radius:8px;}
+.menu-list li a:hover{background:rgba(0,0,0,0.1);}
+.material-icons{font-size:22px;line-height:1;}
 .dashboard{padding-top:80px;max-width:1200px;margin:0 auto;}
 .dashboard-grid{
   display:grid;
@@ -84,7 +109,7 @@ body.home-dashboard::before{
   background:#f8f9fa;
   color:#212529;
 }
-.home-dashboard.light .portal-nav{
+.home-dashboard.light .dash-header{
   background:rgba(255,255,255,0.8);
   color:#212529;
 }
@@ -98,5 +123,3 @@ body.home-dashboard::before{
 }
 .home-dashboard.light .announcement-item{border-bottom:1px solid rgba(0,0,0,0.1);}
 .home-dashboard.light .announcement-item .date{color:#6c757d;}
-.home-dashboard.light .nav-right button,.home-dashboard.light .nav-right a{color:#212529;}
-.home-dashboard.light .nav-right a.logout-btn{background:#dc3545;color:#fff;}

--- a/assets/header.js
+++ b/assets/header.js
@@ -1,0 +1,28 @@
+document.addEventListener('DOMContentLoaded',()=>{
+  const header=document.querySelector('.dash-header');
+  let lastY=window.scrollY;
+  window.addEventListener('scroll',()=>{
+    if(window.scrollY>lastY && window.scrollY>80){
+      header.classList.add('hide');
+    }else{
+      header.classList.remove('hide');
+    }
+    lastY=window.scrollY;
+  });
+  const menu=document.getElementById('settingsMenu');
+  const openBtn=document.getElementById('settingsBtn');
+  const closeBtn=menu?.querySelector('.close-btn');
+  function toggle(open){
+    if(open){
+      menu.classList.add('open');
+      menu.setAttribute('aria-hidden','false');
+      document.body.style.overflow='hidden';
+    }else{
+      menu.classList.remove('open');
+      menu.setAttribute('aria-hidden','true');
+      document.body.style.overflow='';
+    }
+  }
+  openBtn?.addEventListener('click',()=>toggle(true));
+  closeBtn?.addEventListener('click',()=>toggle(false));
+});

--- a/assets/user-dropdown.css
+++ b/assets/user-dropdown.css
@@ -1,8 +1,10 @@
 .drop-down{display:inline-block;position:relative;}
-.nav-right .drop-down{margin-left:12px;}
+.quick-actions .drop-down{margin-left:8px;}
 .drop-down__button{background:transparent;border:none;color:inherit;padding:4px;cursor:pointer;display:flex;align-items:center;}
 .drop-down__name{display:none;}
 .drop-down__icon{width:20px;height:20px;font-size:20px;line-height:20px;transition:transform .3s;display:block;transform-origin:center;text-align:center;}
+.avatar-btn .drop-down__icon{display:none;}
+.avatar-initial{pointer-events:none;}
 .drop-down--active .drop-down__icon{transform:rotate(180deg);}
 .drop-down__menu-box{position:absolute;right:0;left:auto;top:100%;min-width:160px;width:max-content;background:#fff;border-radius:6px;box-shadow:0 4px 12px rgba(0,0,0,0.05);margin-top:5px;border:1px solid #eee;visibility:hidden;opacity:0;transition:all .2s;z-index:1000;}
 .drop-down--active .drop-down__menu-box{visibility:visible;opacity:1;margin-top:10px;}

--- a/index.php
+++ b/index.php
@@ -110,6 +110,7 @@ function render_auth($count, $registrations_open, $hide_register_button) {
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <?php if($theme === 'dashboard'): ?>
     <link rel="stylesheet" href="assets/dashboard.css">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <?php endif; ?>
     <link rel="stylesheet" href="assets/user-dropdown.css">
 </head>
@@ -153,6 +154,9 @@ function render_auth($count, $registrations_open, $hide_register_button) {
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="assets/theme.js"></script>
+    <?php if($theme === 'dashboard'): ?>
+    <script src="assets/header.js"></script>
+    <?php endif; ?>
     <script src="assets/user-dropdown.js"></script>
 </body>
 </html>

--- a/modules/home.php
+++ b/modules/home.php
@@ -13,33 +13,46 @@ if($theme === 'dashboard'):
     $pdo->exec("CREATE TABLE IF NOT EXISTS announcements (id INT AUTO_INCREMENT PRIMARY KEY, content TEXT NOT NULL, publish_date DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP)");
     $announcements = $pdo->query('SELECT content, publish_date FROM announcements ORDER BY publish_date DESC')->fetchAll();
 ?>
-<nav class="portal-nav">
 <script>document.body.classList.add('home-dashboard');</script>
-  <div class="nav-left">
-    <div class="portal-logo"><?php echo htmlspecialchars($site_name); ?></div>
-    <div class="welcome">Hoşgeldiniz, <?php echo htmlspecialchars($full); ?></div>
-    <span class="role-pill"><?php echo htmlspecialchars($role); ?></span>
+<nav class="dash-header" aria-label="Üst Menü">
+  <div class="site-info">
+    <span class="site-name"><?php echo htmlspecialchars($site_name); ?></span>
+    <span class="welcome">Hoşgeldiniz, <?php echo htmlspecialchars($full); ?></span>
   </div>
-  <div class="nav-right">
+  <div class="quick-actions">
+    <button class="icon-btn" id="settingsBtn" aria-label="Ayarlar"><span class="material-icons">settings</span></button>
+    <button class="icon-btn" id="notifBtn" aria-label="Bildirimler"><span class="material-icons">notifications</span><span class="badge" id="notifBadge" hidden></span></button>
+    <button class="icon-btn" id="themeToggleGlobal" aria-label="Tema">🌙</button>
     <div class="drop-down">
-      <div class="drop-down__button">
-        <span class="drop-down__name">Ayarlar</span>
-        <i class="fa-solid fa-gear drop-down__icon"></i>
-      </div>
+      <button class="avatar-btn drop-down__button" aria-label="Kullanıcı">
+        <span class="avatar-initial"><?php echo mb_strtoupper(mb_substr($full,0,1)); ?></span>
+      </button>
       <div class="drop-down__menu-box">
         <ul class="drop-down__menu">
-          <li class="drop-down__item"><a href="pages/profile.php"><i class="fa-solid fa-user drop-down__item-icon"></i><span class="drop-down__item-text">Profil</span></a></li>
-          <li class="drop-down__item"><a href="pages/messages.php"><i class="fa-solid fa-envelope drop-down__item-icon"></i><span class="drop-down__item-text">Mesajlar</span></a></li>
-          <?php if($role === 'admin'): ?>
-          <li class="drop-down__item"><a href="pages/admin.php"><i class="fa-solid fa-toolbox drop-down__item-icon"></i><span class="drop-down__item-text">Admin Paneli</span></a></li>
-          <?php endif; ?>
+          <li class="drop-down__item"><a href="pages/profile.php"><span class="material-icons drop-down__item-icon">person</span><span class="drop-down__item-text">Profil</span></a></li>
+          <li class="drop-down__item"><a href="pages/logout.php"><span class="material-icons drop-down__item-icon">logout</span><span class="drop-down__item-text">Çıkış</span></a></li>
         </ul>
       </div>
     </div>
-    <button id="themeToggleGlobal" aria-label="Tema" role="button">🌙</button>
-    <a href="pages/logout.php" class="logout-btn" aria-label="Çıkış" role="button"><i class="fa-solid fa-arrow-right-from-bracket"></i> Çıkış</a>
   </div>
 </nav>
+<div class="settings-menu" id="settingsMenu" aria-hidden="true">
+  <div class="menu-header">
+    <span class="menu-title"><?php echo htmlspecialchars($site_name); ?></span>
+    <button class="close-btn" aria-label="Kapat">✕</button>
+  </div>
+  <p class="menu-welcome">Hoşgeldiniz, <?php echo htmlspecialchars($full); ?></p>
+  <ul class="menu-list">
+    <li><a href="pages/profile.php"><span class="material-icons">person</span>Profil</a></li>
+    <li><a href="pages/messages.php"><span class="material-icons">mail</span>Mesajlar</a></li>
+    <li><a href="pages/worklist.php"><span class="material-icons">checklist</span>Çalışma Listesi</a></li>
+    <li><a href="pages/training.php"><span class="material-icons">school</span>Eğitimler</a></li>
+    <?php if($role === 'admin'): ?>
+    <li><a href="pages/admin.php"><span class="material-icons">admin_panel_settings</span>Admin Paneli</a></li>
+    <?php endif; ?>
+    <li><a href="pages/logout.php"><span class="material-icons">logout</span>Çıkış</a></li>
+  </ul>
+</div>
 <div class="dashboard">
   <?php
     $modCols = $pdo->query("SHOW COLUMNS FROM modules")->fetchAll(PDO::FETCH_COLUMN);


### PR DESCRIPTION
## Summary
- redesign dashboard header for better mobile experience
- create slide-out settings menu and avatar dropdown
- style header with CSS variables and material icons
- add JavaScript for sticky header behaviour
- load new resources when dashboard theme is active

## Testing
- `php -l modules/home.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844d212fdac8330bb1b3530aeedfad9