### PR TITLE
Implement modern mobile dashboard header

### DIFF
--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -1,6 +1,12 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
 :root{
+  --bg:#f8f9fa;
+  --fg:#212529;
   --accent:#0dd4a3;
+}
+body.dark{
+  --bg:#142438;
+  --fg:#fff;
 }
 body.home-dashboard{
   font-family:'Inter',sans-serif;
@@ -25,20 +31,25 @@ body.home-dashboard::before{
   justify-content:space-between;
   align-items:center;
   padding:12px 24px;
-  position:fixed;
+  position:sticky;
   top:0;left:0;right:0;
-  background:rgba(14,27,43,0.8);
+  background:var(--bg);
+  color:var(--fg);
   backdrop-filter:blur(6px);
   box-shadow:0 2px 4px rgba(0,0,0,0.4);
   z-index:10;
+  transition:transform .3s;
 }
+.portal-nav.hide{transform:translateY(-100%);}
 .portal-logo{font-size:24px;font-weight:700;text-transform:uppercase;}
 .nav-left{display:flex;flex-direction:column;line-height:1.2;}
 .nav-left .welcome{font-size:14px;margin-top:2px;}
 .role-pill{background:rgba(255,255,255,0.15);padding:2px 8px;border-radius:9999px;font-size:12px;margin-top:2px;display:inline-block;}
-.nav-right button,.nav-right a{background:none;border:none;color:#fff;margin-left:12px;font-size:16px;cursor:pointer;border-radius:8px;padding:6px;}
-.nav-right a.logout-btn{background:#ff3b3b;padding:6px 12px;}
-.nav-right button:hover,.nav-right a:hover{filter:brightness(1.2);}
+.nav-actions{display:flex;align-items:center;gap:8px;}
+.nav-actions .icon-btn{background:none;border:none;color:var(--fg);width:22px;height:22px;font-size:22px;display:flex;align-items:center;justify-content:center;position:relative;cursor:pointer;}
+.nav-actions .logout-btn{background:#ff3b3b;padding:6px 12px;color:#fff;border-radius:8px;}
+.nav-actions .icon-btn:hover,.nav-actions .logout-btn:hover{filter:brightness(1.2);}
+.nav-actions .badge{position:absolute;top:-4px;right:-4px;background:var(--accent);color:#fff;border-radius:9999px;font-size:10px;padding:1px 4px;line-height:1;}
 .dashboard{padding-top:80px;max-width:1200px;margin:0 auto;}
 .dashboard-grid{
   display:grid;
@@ -98,5 +109,23 @@ body.home-dashboard::before{
 }
 .home-dashboard.light .announcement-item{border-bottom:1px solid rgba(0,0,0,0.1);}
 .home-dashboard.light .announcement-item .date{color:#6c757d;}
-.home-dashboard.light .nav-right button,.home-dashboard.light .nav-right a{color:#212529;}
-.home-dashboard.light .nav-right a.logout-btn{background:#dc3545;color:#fff;}
+.home-dashboard.light .nav-actions .icon-btn{color:#212529;}
+.home-dashboard.light .nav-actions .logout-btn{background:#dc3545;color:#fff;}
+@media (max-width:600px){
+  .portal-nav{height:64px;padding:0 16px;}
+  .nav-left .welcome{font-size:12px;}
+  .nav-actions .logout-btn{display:none;}
+}
+@media (max-width:360px){
+  .nav-left .welcome{display:none;}
+}
+.mobile-menu{position:fixed;inset:0;background:var(--bg);color:var(--fg);display:none;flex-direction:column;z-index:100;transform:translateX(100%);transition:transform .3s;}
+.mobile-menu.open{display:flex;transform:translateX(0);}
+.mobile-menu .close-btn{align-self:flex-end;background:none;border:none;color:var(--fg);font-size:24px;padding:16px;}
+.mobile-menu .menu-welcome{padding:0 24px;font-size:14px;margin-bottom:12px;}
+.mobile-menu .menu-list{list-style:none;padding:0;margin:0;}
+.mobile-menu .menu-list li{border-bottom:1px solid rgba(0,0,0,0.1);}
+body.dark .mobile-menu .menu-list li{border-color:rgba(255,255,255,0.1);}
+.mobile-menu .menu-list a{display:flex;align-items:center;padding:12px 24px;font-size:16px;color:var(--fg);text-decoration:none;line-height:48px;}
+.mobile-menu .menu-list a i{font-size:24px;margin-right:12px;}
+}

--- a/assets/header.js
+++ b/assets/header.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded',()=>{
+  const menuBtn=document.getElementById('mobileMenuBtn');
+  const menu=document.getElementById('mobileMenu');
+  const closeBtn=document.getElementById('closeMenu');
+  menuBtn&&menuBtn.addEventListener('click',()=>menu&&menu.classList.add('open'));
+  closeBtn&&closeBtn.addEventListener('click',()=>menu&&menu.classList.remove('open'));
+  let last=window.scrollY;const header=document.querySelector('.portal-nav');
+  window.addEventListener('scroll',()=>{
+    if(!header)return;
+    const cur=window.scrollY;
+    if(cur>last&&cur>50){header.classList.add('hide');}
+    else{header.classList.remove('hide');}
+    last=cur;
+  });
+});

--- a/index.php
+++ b/index.php
@@ -108,6 +108,7 @@ function render_auth($count, $registrations_open, $hide_register_button) {
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="assets/style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <?php if($theme === 'dashboard'): ?>
     <link rel="stylesheet" href="assets/dashboard.css">
     <?php endif; ?>
@@ -154,5 +155,6 @@ function render_auth($count, $registrations_open, $hide_register_button) {
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="assets/theme.js"></script>
     <script src="assets/user-dropdown.js"></script>
+    <script src="assets/header.js"></script>
 </body>
 </html>

--- a/modules/home.php
+++ b/modules/home.php
@@ -13,33 +13,49 @@ if($theme === 'dashboard'):
     $pdo->exec("CREATE TABLE IF NOT EXISTS announcements (id INT AUTO_INCREMENT PRIMARY KEY, content TEXT NOT NULL, publish_date DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP)");
     $announcements = $pdo->query('SELECT content, publish_date FROM announcements ORDER BY publish_date DESC')->fetchAll();
 ?>
-<nav class="portal-nav">
+<nav class="portal-nav" aria-label="Üst Menü">
 <script>document.body.classList.add('home-dashboard');</script>
   <div class="nav-left">
     <div class="portal-logo"><?php echo htmlspecialchars($site_name); ?></div>
     <div class="welcome">Hoşgeldiniz, <?php echo htmlspecialchars($full); ?></div>
     <span class="role-pill"><?php echo htmlspecialchars($role); ?></span>
   </div>
-  <div class="nav-right">
-    <div class="drop-down">
-      <div class="drop-down__button">
-        <span class="drop-down__name">Ayarlar</span>
-        <i class="fa-solid fa-gear drop-down__icon"></i>
-      </div>
+  <div class="nav-actions">
+    <button id="notifBtn" class="icon-btn" aria-label="Bildirimler">
+      <span class="material-icons">notifications</span>
+      <?php if(!empty($unreadCount)): ?><span class="badge"><?php echo $unreadCount; ?></span><?php endif; ?>
+    </button>
+    <button id="themeToggleGlobal" class="icon-btn" aria-label="Tema">🌙</button>
+    <div class="drop-down avatar">
+      <button class="drop-down__button icon-btn" aria-label="Kullanıcı">
+        <?php echo strtoupper(mb_substr($full,0,1)); ?>
+      </button>
       <div class="drop-down__menu-box">
         <ul class="drop-down__menu">
-          <li class="drop-down__item"><a href="pages/profile.php"><i class="fa-solid fa-user drop-down__item-icon"></i><span class="drop-down__item-text">Profil</span></a></li>
-          <li class="drop-down__item"><a href="pages/messages.php"><i class="fa-solid fa-envelope drop-down__item-icon"></i><span class="drop-down__item-text">Mesajlar</span></a></li>
-          <?php if($role === 'admin'): ?>
-          <li class="drop-down__item"><a href="pages/admin.php"><i class="fa-solid fa-toolbox drop-down__item-icon"></i><span class="drop-down__item-text">Admin Paneli</span></a></li>
-          <?php endif; ?>
+          <li class="drop-down__item"><a href="pages/profile.php">Profil</a></li>
+          <li class="drop-down__item"><a href="pages/logout.php">Çıkış</a></li>
         </ul>
       </div>
     </div>
-    <button id="themeToggleGlobal" aria-label="Tema" role="button">🌙</button>
-    <a href="pages/logout.php" class="logout-btn" aria-label="Çıkış" role="button"><i class="fa-solid fa-arrow-right-from-bracket"></i> Çıkış</a>
+    <button id="mobileMenuBtn" class="icon-btn" aria-label="Ayarlar">
+      <span class="material-icons">menu</span>
+    </button>
   </div>
 </nav>
+<div id="mobileMenu" class="mobile-menu" aria-label="Mobil Menü">
+  <button id="closeMenu" class="close-btn" aria-label="Kapat">✕</button>
+  <div class="menu-welcome">Hoşgeldiniz, <?php echo htmlspecialchars($full); ?></div>
+  <ul class="menu-list">
+    <li><a href="pages/profile.php"><span class="material-icons">person</span> Profil</a></li>
+    <li><a href="pages/messages.php"><span class="material-icons">mail</span> Mesajlar</a></li>
+    <li><a href="index.php?module=shift"><span class="material-icons">list</span> Çalışma Listesi</a></li>
+    <li><a href="index.php?module=training"><span class="material-icons">school</span> Eğitimler</a></li>
+    <?php if($role === 'admin'): ?>
+    <li><a href="pages/admin.php"><span class="material-icons">admin_panel_settings</span> Admin Paneli</a></li>
+    <?php endif; ?>
+    <li><a href="pages/logout.php"><span class="material-icons">logout</span> Çıkış</a></li>
+  </ul>
+</div>
 <div class="dashboard">
   <?php
     $modCols = $pdo->query("SHOW COLUMNS FROM modules")->fetchAll(PDO::FETCH_COLUMN);


### PR DESCRIPTION
## Summary
- redesign dashboard header for mobile screens
- add slide-over mobile menu and quick actions
- support dark/light theme via CSS variables
- handle menu interactions and scroll hide in `header.js`
- include Material Icons

## Testing
- `npm test` *(fails: no test specified)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d51db70c8330bfbef603db062db3