### PR TITLE
Add dropdown menu for desktop

### DIFF
--- a/assets/header.js
+++ b/assets/header.js
@@ -2,7 +2,13 @@ document.addEventListener('DOMContentLoaded',()=>{
   const menuBtn=document.getElementById('mobileMenuBtn');
   const menu=document.getElementById('mobileMenu');
   const closeBtn=document.getElementById('closeMenu');
-  menuBtn&&menuBtn.addEventListener('click',()=>menu&&menu.classList.add('open'));
+  if(menuBtn){
+    menuBtn.addEventListener('click',()=>{
+      if(window.innerWidth<768 && menu){
+        menu.classList.add('open');
+      }
+    });
+  }
   closeBtn&&closeBtn.addEventListener('click',()=>menu&&menu.classList.remove('open'));
   let last=window.scrollY;const header=document.querySelector('.portal-nav');
   window.addEventListener('scroll',()=>{

--- a/assets/user-dropdown.js
+++ b/assets/user-dropdown.js
@@ -4,6 +4,7 @@ document.addEventListener('DOMContentLoaded',()=>{
   dropdowns.forEach(dd=>{
     const btn=dd.querySelector('.drop-down__button');
     if(!btn) return;
+    if(btn.id==='mobileMenuBtn' && window.innerWidth<768) return;
     btn.addEventListener('click',e=>{
       e.stopPropagation();
       dd.classList.toggle('drop-down--active');

--- a/modules/home.php
+++ b/modules/home.php
@@ -37,9 +37,23 @@ if($theme === 'dashboard'):
         </ul>
       </div>
     </div>
-    <button id="mobileMenuBtn" class="icon-btn" aria-label="Ayarlar">
-      <span class="material-icons">menu</span>
-    </button>
+    <div class="drop-down" id="desktopMenu">
+      <button id="mobileMenuBtn" class="icon-btn drop-down__button" aria-label="Ayarlar">
+        <span class="material-icons">menu</span>
+      </button>
+      <div class="drop-down__menu-box">
+        <ul class="drop-down__menu">
+          <li class="drop-down__item"><a href="pages/profile.php"><span class="material-icons drop-down__item-icon">person</span><span class="drop-down__item-text">Profil</span></a></li>
+          <li class="drop-down__item"><a href="pages/messages.php"><span class="material-icons drop-down__item-icon">mail</span><span class="drop-down__item-text">Mesajlar</span></a></li>
+          <li class="drop-down__item"><a href="index.php?module=shift"><span class="material-icons drop-down__item-icon">list</span><span class="drop-down__item-text">Çalışma Listesi</span></a></li>
+          <li class="drop-down__item"><a href="index.php?module=training"><span class="material-icons drop-down__item-icon">school</span><span class="drop-down__item-text">Eğitimler</span></a></li>
+          <?php if($role === 'admin'): ?>
+          <li class="drop-down__item"><a href="pages/admin.php"><span class="material-icons drop-down__item-icon">admin_panel_settings</span><span class="drop-down__item-text">Admin Paneli</span></a></li>
+          <?php endif; ?>
+          <li class="drop-down__item"><a href="pages/logout.php"><span class="material-icons drop-down__item-icon">logout</span><span class="drop-down__item-text">Çıkış</span></a></li>
+        </ul>
+      </div>
+    </div>
   </div>
 </nav>
 <div id="mobileMenu" class="mobile-menu" aria-label="Mobil Menü">


### PR DESCRIPTION
## Summary
- show dropdown navigation when clicking the menu button on desktop
- keep slideout menu for small screens

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6844e14ad7cc83309ae1b11a7ae3cc40