### PR TITLE
Add reusable styles for admin message selects

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -75,3 +75,17 @@ body.light .admin-sidebar{
 .admin-layout .navbar{
   z-index:1101;
 }
+
+/* message select dropdown sizing */
+.msg-select{
+  max-width:100%;
+  margin-right:.5rem;
+  margin-bottom:.5rem;
+}
+@media(max-width:768px){
+  .msg-select{
+    margin-right:0;
+  }
+}
+
+#toSelect{display:none;}

--- a/pages/admin.php
+++ b/pages/admin.php
@@ -752,12 +752,12 @@ function render_auth($count, $registrations_open, $hide_register_button) {
                     <input type="hidden" name="action" value="send">
                     <input type="hidden" name="u1" value="<?php echo htmlspecialchars($u1); ?>">
                     <input type="hidden" name="u2" value="<?php echo htmlspecialchars($u2); ?>">
-                    <select name="from" id="fromSelect" class="form-select me-md-2 mb-2 flex-grow-1" style="max-width:150px;">
+                    <select name="from" id="fromSelect" class="form-select me-md-2 mb-2 flex-grow-1 msg-select">
                         <option value="<?php echo htmlspecialchars($u1); ?>"><?php echo htmlspecialchars($u1); ?> olarak</option>
                         <option value="<?php echo htmlspecialchars($u2); ?>"><?php echo htmlspecialchars($u2); ?> olarak</option>
                         <option value="<?php echo htmlspecialchars($_SESSION['user']); ?>">Admin olarak</option>
                     </select>
-                    <select name="to" id="toSelect" class="form-select me-md-2 mb-2 flex-grow-1" style="max-width:150px; display:none;">
+                    <select name="to" id="toSelect" class="form-select me-md-2 mb-2 flex-grow-1 msg-select">
                         <option value="<?php echo htmlspecialchars($u1); ?>"><?php echo htmlspecialchars($u1); ?></option>
                         <option value="<?php echo htmlspecialchars($u2); ?>"><?php echo htmlspecialchars($u2); ?></option>
                     </select>


### PR DESCRIPTION
## Summary
- add `.msg-select` class in admin styles
- hide `#toSelect` with CSS
- use the new class on admin message select elements

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6844eb4584b88330967c98d8ffa173ce