### PR TITLE
Add scrollable message history style

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -89,3 +89,9 @@ body.light .admin-sidebar{
 }
 
 #toSelect{display:none;}
+
+/* message history scroll container */
+.msg-history{
+  max-height:50vh;
+  overflow-y:auto;
+}

--- a/pages/admin.php
+++ b/pages/admin.php
@@ -736,7 +736,7 @@ function render_auth($count, $registrations_open, $hide_register_button) {
                         }
                     }
                 ?>
-                <div class="border p-2 mb-3" style="max-height:300px;overflow-y:auto;">
+                <div class="border p-2 mb-3 msg-history">
                 <?php foreach($conv as $m): ?>
                     <div class="d-flex <?php echo $m['sender_id']==$id1? 'justify-content-start':'justify-content-end'; ?>">
                         <div class="bubble <?php echo $m['sender_id']==$id1? 'theirs':'mine'; ?><?php if($m['role']==='admin') echo ' admin-msg'; ?>">


### PR DESCRIPTION
## Summary
- style admin message history in CSS
- use the new class instead of inline styles

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6844ec3ea61c8330800ca81a037d9763