### PR TITLE
Improve admin message history height

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -107,10 +107,14 @@ body.light .admin-sidebar{
   overflow-y:auto;
 }
 
-/* stacked card layout for small screens */
-.stack-cards{display:none;}
-
 @media(max-width:575.98px){
+  .msg-history{
+    /* fill more of the screen on small devices */
+    max-height:calc(100vh - 260px);
+  }
   .stack-table{display:none;}
   .stack-cards{display:block;}
 }
+
+/* stacked card layout for small screens */
+.stack-cards{display:none;}


### PR DESCRIPTION
## Summary
- allow the chat history in the admin panel to take up more space on phones

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6844f705f4d483309af66bf43b1b6161