### PR TITLE
Adjust login ring to use viewport units

### DIFF
--- a/assets/login.css
+++ b/assets/login.css
@@ -16,8 +16,10 @@ body {
 }
 .ring {
   position: relative;
-  width: 500px;
-  height: 500px;
+  width: 90vw;
+  height: 90vw;
+  max-width: 500px;
+  max-height: 500px;
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
## Summary
- make the login ring responsive by using viewport width units
- keep ring centered with flexbox

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6844f790189c8330ab996dcee6409ce7