### PR TITLE
Fix login link wrapping on small screens

### DIFF
--- a/assets/login.css
+++ b/assets/login.css
@@ -136,8 +136,18 @@ body {
   align-items: center;
   justify-content: space-between;
   padding: 0 20px;
+  flex-wrap: wrap;
+  gap: 5px;
 }
 .login .links a {
   color: #fff;
   text-decoration: none;
+}
+
+@media (max-width: 400px) {
+  .login .links {
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+  }
 }


### PR DESCRIPTION
## Summary
- let login links wrap and add mobile style

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6844f9e568cc83309ee9159b16adc10f