### PR TITLE
Fix login ring scaling

### DIFF
--- a/assets/login.css
+++ b/assets/login.css
@@ -16,10 +16,11 @@ body {
 }
 .ring {
   position: relative;
-  width: 90vw;
-  height: 90vw;
+  width: min(90vw, 500px);
+  height: auto;
+  aspect-ratio: 1 / 1;
   max-width: 500px;
-  max-height: 500px;
+  max-height: 90vh;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -154,10 +155,11 @@ body {
 
 @media (max-width: 576px) {
   .ring {
-    width: 100vw;
+    width: min(100vw, 500px);
     height: auto;
+    aspect-ratio: 1 / 1;
     max-width: none;
-    max-height: none;
+    max-height: 90vh;
     padding: 20px;
   }
   .login {


### PR DESCRIPTION
## Summary
- let the login ring scale while keeping aspect ratio
- ensure the ring never exceeds the viewport height on small displays

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6844feb1f084833089c1e88b943c7937