### PR TITLE
Fix password field layout

### DIFF
--- a/assets/login.css
+++ b/assets/login.css
@@ -93,13 +93,9 @@ body {
   outline: none;
 }
 .login .inputBx .toggle-password {
-  position: absolute;
-  right: 1rem;
-  top: 50%;
-  transform: translateY(-50%);
-  font-size: 1.2em;
   cursor: pointer;
   color: #fff;
+  font-size: 1.2em;
 }
 .login .inputBx input[type="submit"] {
   width: 100%;

--- a/pages/login.php
+++ b/pages/login.php
@@ -48,8 +48,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     <input type="text" name="username" placeholder="Kullanıcı Adı" required>
                 </div>
                 <div class="inputBx">
-                    <input type="password" name="password" placeholder="Şifre" required>
-                    <i class="toggle-password bi bi-eye"></i>
+                    <div class="input-group">
+                        <input type="password" name="password" placeholder="Şifre" class="form-control" required>
+                        <span class="input-group-text"><i class="toggle-password bi bi-eye"></i></span>
+                    </div>
                 </div>
                 <div class="inputBx">
                     <input type="submit" value="Giriş Yap">
@@ -68,7 +70,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <script>
         document.querySelectorAll('.toggle-password').forEach(function(el) {
             el.addEventListener('click', function() {
-                const input = this.previousElementSibling;
+                const input = this.closest('.input-group').querySelector('input');
                 if (input.type === 'password') {
                     input.type = 'text';
                     this.classList.remove('bi-eye');

--- a/pages/register.php
+++ b/pages/register.php
@@ -53,8 +53,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     <input type="email" name="email" placeholder="E-posta" required>
                 </div>
                 <div class="inputBx">
-                    <input type="password" name="password" placeholder="Şifre" required>
-                    <i class="toggle-password bi bi-eye"></i>
+                    <div class="input-group">
+                        <input type="password" name="password" placeholder="Şifre" class="form-control" required>
+                        <span class="input-group-text"><i class="toggle-password bi bi-eye"></i></span>
+                    </div>
                 </div>
                 <div class="inputBx">
                     <select name="role">
@@ -78,7 +80,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <script>
         document.querySelectorAll('.toggle-password').forEach(function(el) {
             el.addEventListener('click', function() {
-                const input = this.previousElementSibling;
+                const input = this.closest('.input-group').querySelector('input');
                 if (input.type === 'password') {
                     input.type = 'text';
                     this.classList.remove('bi-eye');


### PR DESCRIPTION
## Summary
- make password fields use Bootstrap input groups
- place visibility toggle inside `.input-group-text`
- update scripts to locate the input field by nearest input-group

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6845676ef9c48330aebc3426e3f89c25