### PR TITLE
Add labels to auth forms

### DIFF
--- a/assets/login.css
+++ b/assets/login.css
@@ -80,6 +80,11 @@ body {
   position: relative;
   width: 100%;
 }
+.login .inputBx label {
+  display: block;
+  margin-bottom: 5px;
+  color: #fff;
+}
 .login .inputBx input {
   position: relative;
   width: 100%;

--- a/pages/forgot_password.php
+++ b/pages/forgot_password.php
@@ -39,7 +39,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <?php if ($message) echo "<div class='alert alert-info'>$message</div>"; ?>
         <form method="post">
             <div class="inputBx">
-                <input type="text" name="identifier" placeholder="Kullanıcı Adı veya E-posta" required>
+                <label for="identifier" class="form-label">Kullanıcı Adı veya E-posta</label>
+                <input id="identifier" type="text" name="identifier" placeholder="Kullanıcı Adı veya E-posta" required>
             </div>
             <div class="inputBx">
                 <input type="submit" value="Gönder">

--- a/pages/login.php
+++ b/pages/login.php
@@ -45,11 +45,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             <?php if ($error) echo "<div class='alert alert-danger'>$error</div>"; ?>
             <form method="post">
                 <div class="inputBx">
-                    <input type="text" name="username" placeholder="Kullanıcı Adı" required>
+                    <label for="username" class="form-label">Kullanıcı Adı</label>
+                    <input id="username" type="text" name="username" placeholder="Kullanıcı Adı" required>
                 </div>
                 <div class="inputBx">
+                    <label for="password" class="form-label">Şifre</label>
                     <div class="input-group">
-                        <input type="password" name="password" placeholder="Şifre" class="form-control" required>
+                        <input id="password" type="password" name="password" placeholder="Şifre" class="form-control" required>
                         <span class="input-group-text"><i class="toggle-password bi bi-eye"></i></span>
                     </div>
                 </div>

--- a/pages/register.php
+++ b/pages/register.php
@@ -47,19 +47,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             <?php if ($message) echo "<div class='alert alert-info'>$message</div>"; ?>
             <form method="post">
                 <div class="inputBx">
-                    <input type="text" name="username" placeholder="Kullanıcı Adı" required>
+                    <label for="reg_username" class="form-label">Kullanıcı Adı</label>
+                    <input id="reg_username" type="text" name="username" placeholder="Kullanıcı Adı" required>
                 </div>
                 <div class="inputBx">
-                    <input type="email" name="email" placeholder="E-posta" required>
+                    <label for="reg_email" class="form-label">E-posta</label>
+                    <input id="reg_email" type="email" name="email" placeholder="E-posta" required>
                 </div>
                 <div class="inputBx">
+                    <label for="reg_password" class="form-label">Şifre</label>
                     <div class="input-group">
-                        <input type="password" name="password" placeholder="Şifre" class="form-control" required>
+                        <input id="reg_password" type="password" name="password" placeholder="Şifre" class="form-control" required>
                         <span class="input-group-text"><i class="toggle-password bi bi-eye"></i></span>
                     </div>
                 </div>
                 <div class="inputBx">
-                    <select name="role">
+                    <label for="reg_role" class="form-label">Rol</label>
+                    <select id="reg_role" name="role">
                         <?php foreach (default_roles() as $r): ?>
                         <option value="<?php echo htmlspecialchars($r); ?>"><?php echo htmlspecialchars($r); ?></option>
                         <?php endforeach; ?>

--- a/pages/reset_password.php
+++ b/pages/reset_password.php
@@ -43,10 +43,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             <?php if ($message) echo "<div class='alert alert-danger'>$message</div>"; ?>
             <form method="post">
                 <div class="inputBx">
-                    <input type="password" name="password" placeholder="Yeni Şifre" required>
+                    <label for="new_password" class="form-label">Yeni Şifre</label>
+                    <input id="new_password" type="password" name="password" placeholder="Yeni Şifre" required>
                 </div>
                 <div class="inputBx">
-                    <input type="password" name="password2" placeholder="Yeni Şifre (Tekrar)" required>
+                    <label for="new_password2" class="form-label">Yeni Şifre (Tekrar)</label>
+                    <input id="new_password2" type="password" name="password2" placeholder="Yeni Şifre (Tekrar)" required>
                 </div>
                 <div class="inputBx">
                     <input type="submit" value="Sıfırla">


### PR DESCRIPTION
## Summary
- add CSS for form labels on login screens
- label login form fields for username and password
- label registration form fields for username, email, password, and role
- label password reset and recovery forms

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6845686461ac83309ce9404eea9bfa74