### PR TITLE
Fix select styling for theme compatibility

### DIFF
--- a/assets/login.css
+++ b/assets/login.css
@@ -113,20 +113,11 @@ body {
   color: rgba(255, 255, 255, 0.75);
 }
 .login .inputBx select {
-  position: relative;
   width: 100%;
   padding: 12px 20px;
-  background: transparent;
   border: 2px solid #fff;
   border-radius: 40px;
   font-size: 1.2em;
-  color: #fff;
-  box-shadow: none;
-  outline: none;
-}
-.login .inputBx select option {
-  color: #000;
-  background: #fff;
 }
 
 .login .links {

--- a/assets/style.css
+++ b/assets/style.css
@@ -38,10 +38,12 @@ body {
 body.light {
   background-color: #f8f9fa;
   color: #212529;
+  color-scheme: light;
 }
 body.dark {
   background-color: #121212;
   color: #f8f9fa;
+  color-scheme: dark;
 }
 body.dark .card {
   background-color: #1e1e1e;


### PR DESCRIPTION
## Summary
- remove hardcoded colors from registration dropdown
- ensure browsers pick dark/light theme colors with `color-scheme`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68456988d58c833086f95d17389d14ae