### PR TITLE
Fix responsive sizing

### DIFF
--- a/assets/login.css
+++ b/assets/login.css
@@ -73,7 +73,7 @@ body {
   gap: 20px;
 }
 .login h2 {
-  font-size: 2em;
+  font-size: clamp(1.25rem, 4vw, 2rem);
   color: #fff;
 }
 .login .inputBx {
@@ -92,7 +92,7 @@ body {
   background: transparent;
   border: 2px solid #fff;
   border-radius: 40px;
-  font-size: 1.2em;
+  font-size: clamp(0.9rem, 3vw, 1.2rem);
   color: #fff;
   box-shadow: none;
   outline: none;
@@ -100,7 +100,7 @@ body {
 .login .inputBx .toggle-password {
   cursor: pointer;
   color: #fff;
-  font-size: 1.2em;
+  font-size: clamp(0.9rem, 3vw, 1.2rem);
 }
 .login .inputBx input[type="submit"] {
   width: 100%;
@@ -117,7 +117,7 @@ body {
   padding: 12px 20px;
   border: 2px solid #fff;
   border-radius: 40px;
-  font-size: 1.2em;
+  font-size: clamp(0.9rem, 3vw, 1.2rem);
 }
 
 .login .links {
@@ -155,8 +155,5 @@ body {
     position: relative;
     width: 100%;
     max-width: 330px;
-  }
-  .login h2 {
-    font-size: 1.5em;
   }
 }


### PR DESCRIPTION
## Summary
- scale login headings and inputs using `clamp()`
- drop redundant media query for login header

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68456a466a288330b7196beb9c3e0567