### PR TITLE
Fix password input eye icon styling

### DIFF
--- a/assets/login.css
+++ b/assets/login.css
@@ -107,6 +107,20 @@ body {
   box-shadow: none;
   outline: none;
 }
+
+.login .inputBx .input-group .form-control {
+  border-right: none;
+  border-radius: 40px 0 0 40px;
+}
+
+.login .inputBx .input-group-text {
+  border: 2px solid #fff;
+  border-left: none;
+  border-radius: 0 40px 40px 0;
+  background: transparent;
+  color: #fff;
+  cursor: pointer;
+}
 .login .inputBx .toggle-password {
   cursor: pointer;
   color: #fff;


### PR DESCRIPTION
## Summary
- align show-password eye icon with rounded input fields

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68456e6ab45c8330804c693a4fd62321