### PR TITLE
Fix password input group layout

### DIFF
--- a/assets/login.css
+++ b/assets/login.css
@@ -112,6 +112,8 @@ body {
 .login .inputBx .input-group .form-control {
   border-right: none;
   border-radius: 40px 0 0 40px;
+  width: auto;
+  flex: 1 1 auto;
 }
 
 .login .inputBx .input-group-text {
@@ -121,6 +123,8 @@ body {
   background: transparent;
   color: #fff;
   cursor: pointer;
+  display: flex;
+  align-items: center;
 }
 .login .inputBx .toggle-password {
   cursor: pointer;


### PR DESCRIPTION
## Summary
- adjust width and flex for password inputs and eye icon

## Testing
- `npm test` *(fails: no test specified)*
- `composer validate --no-check-publish` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b3fe4bb48330a9cf10bc6188d0ce