### PR TITLE
Add dashboard announcement dropdown

### DIFF
--- a/pages/mark_announcement.php
+++ b/pages/mark_announcement.php
@@ -1,0 +1,21 @@
+<?php
+session_start();
+if(!isset($_SESSION['user'])){
+    http_response_code(403);
+    exit;
+}
+require __DIR__ . '/../includes/db.php';
+require __DIR__ . '/../includes/activity.php';
+update_activity($pdo);
+$pdo->exec("CREATE TABLE IF NOT EXISTS announcement_views (user_id INT PRIMARY KEY, last_seen DATETIME NOT NULL, FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE)");
+$stmt = $pdo->prepare('SELECT id FROM users WHERE username = ?');
+$stmt->execute([$_SESSION['user']]);
+$userId = $stmt->fetchColumn();
+if(!$userId){
+    http_response_code(404);
+    exit;
+}
+$upd = $pdo->prepare('INSERT INTO announcement_views (user_id,last_seen) VALUES (?,NOW()) ON DUPLICATE KEY UPDATE last_seen=NOW()');
+$upd->execute([$userId]);
+header('Content-Type: application/json');
+echo json_encode(['status'=>'ok']);


### PR DESCRIPTION
## Summary
- track which users viewed announcements
- show new announcement count on the notification bell
- open announcement popup from dropdown and mark it read

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845b9e4c5008330afbdd0fd690bf58e