### PR TITLE
Fix notification truncation

### DIFF
--- a/assets/user-dropdown.css
+++ b/assets/user-dropdown.css
@@ -14,6 +14,9 @@
 .drop-down__item:hover{background:#f8f9fa;}
 .drop-down__item a{display:flex;align-items:center;width:100%;text-decoration:none;color:inherit;white-space:normal;word-break:break-word;}
 
+/* Truncate long notification text */
+.drop-down__item .notif-text{display:block;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+
 /* Dark theme overrides */
 body.dark .drop-down__menu-box{background:#1f1f1f;border-color:#333;}
 body.dark .drop-down__item{color:#f8f9fa;border-bottom:1px solid #444;}

--- a/modules/home.php
+++ b/modules/home.php
@@ -52,7 +52,7 @@ if($theme === 'dashboard'):
         <ul class="drop-down__menu">
           <?php if($newAnnCount>0 && !empty($newAnnouncements)): ?>
             <?php foreach($newAnnouncements as $ann): ?>
-              <li class="drop-down__item"><a href="#" class="newAnnLink" data-content="<?php echo htmlspecialchars($ann['content'], ENT_QUOTES); ?>" data-date="<?php echo $ann['publish_date']; ?>"><?php echo htmlspecialchars($ann['content']); ?></a></li>
+              <li class="drop-down__item"><a href="#" class="newAnnLink notif-text" data-content="<?php echo htmlspecialchars($ann['content'], ENT_QUOTES); ?>" data-date="<?php echo $ann['publish_date']; ?>"><?php echo htmlspecialchars($ann['content']); ?></a></li>
             <?php endforeach; ?>
           <?php else: ?>
             <li class="drop-down__item">Bildirim yok</li>


### PR DESCRIPTION
## Summary
- truncate long notifications in dashboard dropdown

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6845cc4775388330912f3550b2965530