### PR TITLE
Fix dark theme on Activity Log

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -120,3 +120,24 @@ body.dark .btn-close {
   flex: 1 1 100%;
   word-break: break-word;
 }
+
+/* Dark theme tweaks for activity log */
+body.dark .table {
+  color: #f8f9fa;
+  background-color: #1e1e1e;
+}
+body.dark .table th,
+body.dark .table td {
+  border-color: #343a40;
+}
+body.dark .table-striped>tbody>tr:nth-of-type(odd) {
+  background-color: rgba(255, 255, 255, 0.05);
+}
+body.dark .form-control {
+  background-color: #343a40;
+  color: #f8f9fa;
+  border-color: #495057;
+}
+body.dark .form-control::placeholder {
+  color: #adb5bd;
+}


### PR DESCRIPTION
## Summary
- tweak dark theme colors for tables and form controls on Activity Log page

## Testing
- `npm test` *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_6845d2e922748330963ef584ca02f3fb