### PR TITLE
Implement calendar status labels

### DIFF
--- a/assets/worklist.css
+++ b/assets/worklist.css
@@ -84,6 +84,7 @@ body.worklist-page section.card {
 .wl-calendar td:hover { outline:1px solid rgba(63,167,255,0.4); cursor:pointer; }
 .wl-calendar td.selected { outline:2px solid #3fa7ff; }
 .wl-calendar .code { position:absolute; top:4px; right:4px; font-size:12px; padding:2px 4px; border-radius:4px; }
+.wl-calendar .status { position:absolute; left:4px; right:4px; bottom:4px; font-size:10px; line-height:1.1; background:rgba(0,0,0,0.6); padding:2px 4px; border-radius:4px; }
 .legend { display:flex; justify-content:center; gap:16px; margin-top:8px; }
 .legend span { display:flex; align-items:center; gap:4px; font-size:14px; }
 .legend .g { background:#3fa7ff; }
@@ -115,7 +116,6 @@ body.worklist-page section.card {
 .request-item .badge.n { background:#dc3545; }
 .request-item .badge.i { background:#198754; }
 .request-item .badge.d { background:#6c757d; }
-.request-item .note { font-style:italic; margin-top:4px; opacity:0.8; }
 .request-item .actions { text-align:right; margin-top:4px; }
 .request-item i { cursor:pointer; margin-left:8px; }
 
@@ -160,6 +160,10 @@ body.worklist-page.light .wl-calendar td {
 }
 body.worklist-page.light .wl-calendar td:hover {
   outline:1px solid rgba(13,110,253,0.3);
+}
+body.worklist-page.light .wl-calendar .status {
+  background:rgba(255,255,255,0.8);
+  color:#212529;
 }
 body.worklist-page.light .wl-modal-card {
   background:#fff;

--- a/assets/worklist.js
+++ b/assets/worklist.js
@@ -4,6 +4,11 @@
   const monthNames = ['Ocak','Şubat','Mart','Nisan','Mayıs','Haziran','Temmuz','Ağustos','Eylül','Ekim','Kasım','Aralık'];
   const dayNames = ['Pzt','Sal','Çar','Per','Cum','Cmt','Paz'];
   let current = new Date();
+  function capitalize(text){
+    const map={i:'İ',ş:'Ş',ğ:'Ğ',ü:'Ü',ö:'Ö',ç:'Ç',ı:'I'};
+    const f=text.charAt(0);
+    return (map[f]||f.toUpperCase())+text.slice(1);
+  }
   const views = document.querySelectorAll('.wl-view');
   document.querySelectorAll('.wl-sidebar li').forEach(li=>{
     li.addEventListener('click',()=>{
@@ -38,7 +43,18 @@
           const dateStr = `${year}-${String(month+1).padStart(2,'0')}-${String(d).padStart(2,'0')}`;
           const span=document.createElement('span'); span.textContent=d; td.appendChild(span);
           const entry=data[dateStr];
-          if(entry){ const code=document.createElement('div'); code.className='code'; code.textContent=entry.type[0].toUpperCase(); code.classList.add(entry.type.charAt(0)); td.appendChild(code); td.style.background=bgColor(entry.type); }
+          if(entry){
+            const code=document.createElement('div');
+            code.className='code';
+            code.textContent=entry.type[0].toUpperCase();
+            code.classList.add(entry.type.charAt(0));
+            td.appendChild(code);
+            const status=document.createElement('div');
+            status.className='status';
+            status.textContent=`${capitalize(entry.type)} İsteğinde Bulunuldu Onay Bekleniyor`;
+            td.appendChild(status);
+            td.style.background=bgColor(entry.type);
+          }
           td.dataset.date=dateStr;
           td.addEventListener('click',()=>openModal(dateStr));
           d++; if(d>daysInMonth) done=true;
@@ -70,7 +86,6 @@
   const modal = document.getElementById('wls-modal');
   const modalDate = modal.querySelector('.subtitle');
   const radios = modal.querySelectorAll('input[name="type"]');
-  const noteEl = modal.querySelector('textarea');
 
   function openModal(date){
     modal.classList.add('active');
@@ -78,7 +93,6 @@
     const d=new Date(date); modalDate.textContent='Seçilen Tarih: '+d.toLocaleDateString('tr-TR',{day:'2-digit',month:'long',year:'numeric',weekday:'long'});
     const entry=data[date]||{};
     radios.forEach(r=>r.checked=r.value===entry.type);
-    noteEl.value=entry.note||'';
   }
   function closeModal(){ modal.classList.remove('active'); }
   modal.querySelector('.cancel').addEventListener('click',closeModal);
@@ -87,8 +101,7 @@
   modal.querySelector('.save').addEventListener('click',()=>{
     const date=modal.dataset.date;
     const type=[...radios].find(r=>r.checked)?.value;
-    const note=noteEl.value.trim();
-    if(type){ data[date]={type,note}; save(); }
+    if(type){ data[date]={type}; save(); }
     closeModal(); renderCalendar(); refreshList();
   });
 
@@ -106,7 +119,6 @@
       const div=document.createElement('div');
       div.className='request-item';
       div.innerHTML=`<div>${new Date(date).toLocaleDateString('tr-TR',{day:'2-digit',month:'long',year:'numeric',weekday:'long'})} <span class="badge ${entry.type.charAt(0)}">${entry.type[0].toUpperCase()}</span></div>`;
-      if(entry.note) div.innerHTML+=`<div class="note">${entry.note}</div>`;
       const actions=document.createElement('div'); actions.className='actions';
       const edit=document.createElement('i'); edit.className='fa-solid fa-pencil';
       const del=document.createElement('i'); del.className='fa-solid fa-trash';

--- a/modules/shift.php
+++ b/modules/shift.php
@@ -45,7 +45,6 @@ function tr_upper(string $text): string {
       <label><input type="radio" name="type" value="izin"> İZİN</label><br>
       <label><input type="radio" name="type" value="diğer"> DİĞER</label>
     </div>
-    <textarea placeholder="İsteğinizi buraya yazın…"></textarea>
     <div class="actions">
       <button class="ghost cancel">İptal</button>
       <button class="fill save">Kaydet</button>


### PR DESCRIPTION
## Summary
- show a status message when a day has a request in the calendar
- remove optional note field from the request modal
- adjust calendar styles to display the status message

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6845d8370b9c8330bcfc8734ab7598d7