### PR TITLE
Fix calendar activation on shift page

### DIFF
--- a/modules/shift.php
+++ b/modules/shift.php
@@ -56,5 +56,5 @@ function tr_upper(string $text): string {
   <div class="header"><span>İsteklerim</span><i class="fa-solid fa-xmark close" style="cursor:pointer"></i></div>
   <div class="list"></div>
 </div>
-<script src="assets/worklist.js"></script>
 <script src="assets/holiday-calendar.js"></script>
+<script src="assets/worklist.js"></script>


### PR DESCRIPTION
## Summary
- load `holiday-calendar.js` before `worklist.js` so calendar items are clickable on first load

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6845e2d51fd88330bfdda25532a28192