### PR TITLE
Make shift sidebar mobile friendly

### DIFF
--- a/assets/worklist.css
+++ b/assets/worklist.css
@@ -1,4 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap');
+:root{
+  --wl-sidebar-width:240px;
+}
 
 body.worklist-page {
   font-family: 'Inter', sans-serif;
@@ -46,15 +49,26 @@ body.worklist-page section.card {
   text-decoration: none;
   font-weight: 500;
 }
+.wl-header .icon-btn{
+  background:none;
+  border:none;
+  color:inherit;
+  font-size:20px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  cursor:pointer;
+}
 
 .wl-container { display: flex; flex: 1; overflow: hidden; }
 
 .wl-sidebar {
-  width: 240px;
+  width: var(--wl-sidebar-width);
   background: linear-gradient(180deg,#0e1b2b,#142438);
   padding-top: 24px;
   display: flex;
   flex-direction: column;
+  transition:transform .3s ease;
 }
 .wl-sidebar ul { list-style: none; padding: 0; margin: 0; flex:1; }
 .wl-sidebar li { color:#fff; padding:12px 16px; display:flex; align-items:center; cursor:pointer; transition:background-color .2s; }
@@ -191,5 +205,30 @@ body.worklist-page.light .request-item {
   background:#f8f9fa;
   color:#212529;
   box-shadow:0 2px 4px rgba(0,0,0,0.1);
+}
+
+/* Mobile Sidebar */
+@media(max-width:768px){
+  :root{--wl-sidebar-width:80vw;}
+  .wl-sidebar{
+    position:fixed;
+    top:64px;
+    left:0;
+    bottom:0;
+    transform:translateX(calc(-1 * var(--wl-sidebar-width)));
+    z-index:1000;
+  }
+  .wl-sidebar.open{
+    transform:translateX(0);
+  }
+  .sidebar-overlay{
+    position:fixed;
+    top:64px;
+    left:0;
+    right:0;
+    bottom:0;
+    background:rgba(0,0,0,0.5);
+    z-index:999;
+  }
 }
 

--- a/assets/worklist.js
+++ b/assets/worklist.js
@@ -152,4 +152,34 @@
   }
 
   renderCalendar();
+
+  // Mobile sidebar toggle
+  const sidebar=document.querySelector('.wl-sidebar');
+  const toggle=document.getElementById('sidebarToggle');
+  let overlay;
+
+  const closeSidebar=()=>{
+    sidebar.classList.remove('open');
+    if(overlay){
+      overlay.removeEventListener('click',closeSidebar);
+      overlay.remove();
+      overlay=null;
+    }
+  };
+
+  const openSidebar=()=>{
+    sidebar.classList.add('open');
+    if(!overlay){
+      overlay=document.createElement('div');
+      overlay.className='sidebar-overlay';
+      overlay.addEventListener('click',closeSidebar);
+      document.body.appendChild(overlay);
+    }
+  };
+
+  if(toggle){
+    toggle.addEventListener('click',()=>{
+      sidebar.classList.contains('open')?closeSidebar():openSidebar();
+    });
+  }
 })();

--- a/modules/shift.php
+++ b/modules/shift.php
@@ -16,6 +16,13 @@ function tr_upper(string $text): string {
 <link rel="stylesheet" href="assets/worklist.css">
 <link rel="stylesheet" href="assets/holiday-calendar.css">
 <div id="wls-app">
+  <header class="wl-header">
+    <div class="left">
+      <button id="sidebarToggle" class="icon-btn" aria-label="Menü"><i class="fa-solid fa-bars"></i></button>
+      <a href="index.php" class="home-link">Ana Sayfa</a>
+    </div>
+    <button id="themeToggleGlobal" class="icon-btn" aria-label="Tema">🌙</button>
+  </header>
   <div class="wl-container">
     <aside class="wl-sidebar">
       <ul>


### PR DESCRIPTION
## Summary
- add mobile-aware sidebar styles for the shift module
- create header with menu and theme toggle
- implement JavaScript to open and close the sidebar

## Testing
- `npm test` *(fails: no test specified)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e66e9a688330a8135fd9cde8140d