### PR TITLE
Fix sidebar toggle on desktop and update header label

### DIFF
--- a/assets/worklist-sidebar.js
+++ b/assets/worklist-sidebar.js
@@ -13,6 +13,9 @@ document.addEventListener('DOMContentLoaded',()=>{
   }
 
   function openSidebar(){
+    if(window.innerWidth>768){
+      return; // desktop layout does not toggle
+    }
     sidebar.classList.add('open');
     if(!overlay){
       overlay=document.createElement('div');
@@ -23,6 +26,9 @@ document.addEventListener('DOMContentLoaded',()=>{
   }
 
   function toggleSidebar(){
+    if(window.innerWidth>768){
+      return; // ignore clicks on desktop
+    }
     if(sidebar.classList.contains('open')){
       closeSidebar();
     }else{

--- a/assets/worklist.css
+++ b/assets/worklist.css
@@ -55,6 +55,10 @@ body.worklist-page section.card {
   cursor:pointer;
 }
 
+@media (min-width: 769px){
+  #wlSidebarToggle{display:none;}
+}
+
 .wl-container { display: flex; flex: 1; overflow: hidden; }
 
 .wl-sidebar {

--- a/modules/shift.php
+++ b/modules/shift.php
@@ -19,7 +19,7 @@ function tr_upper(string $text): string {
   <header class="wl-header">
     <div class="left">
       <button id="wlSidebarToggle" class="menu-toggle" type="button"><i class="fa-solid fa-bars"></i></button>
-      <a href="index.php" class="home-link">Ana Sayfa</a>
+      <a href="index.php" class="home-link">Çalışma Listesi &amp; İstekler</a>
     </div>
   </header>
   <div class="wl-container">


### PR DESCRIPTION
## Summary
- avoid showing sidebar toggle on desktop screens
- no-op the sidebar toggle JS on large screens
- retitle home link to `Çalışma Listesi & İstekler`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6845eeac9ed08330ac0addef68a4a2f8