### PR TITLE
Improve holiday calendar preview

### DIFF
--- a/assets/holiday-calendar.css
+++ b/assets/holiday-calendar.css
@@ -126,6 +126,7 @@
   table-layout: fixed;
   border-collapse: separate;
   border-spacing: 4px;
+  min-height: 452px;
 }
 .hc-container th {
   position: relative;
@@ -154,8 +155,13 @@
   background-color: #dfe7e7;
 }
 .hc-container td:empty { background-color: transparent; }
-.hc-container .is-holiday { color: #fff; background-color: #548383; }
+.hc-container .is-holiday { color: #fff; }
+.hc-container .is-holiday.g { background-color: #3fa7ff; }
+.hc-container .is-holiday.n { background-color: #dc3545; }
+.hc-container .is-holiday.i { background-color: #198754; }
+.hc-container .is-holiday.d { background-color: #6c757d; }
 .hc-container .day { opacity: 0; font-size: 1.1em; font-weight: bold; transition: opacity .4s; }
+.hc-container .is-holiday .day { opacity: 1; }
 .hc-container .split { position: absolute; bottom: 4px; right: 4px; }
 .hc-container .holiday { opacity: 0; margin-top: 8px; font-size: .8em; transition: opacity .4s; }
 .hc-container .notes { width: 708px; margin: 64px auto 0; color: #548383; line-height: 1.8; }

--- a/assets/worklist.js
+++ b/assets/worklist.js
@@ -75,7 +75,8 @@
             td.appendChild(divDay);
             const entry=data[dateStr];
             if(entry){
-              td.classList.add('is-holiday');
+              const code = entry.type.charAt(0);
+              td.classList.add('is-holiday', code);
               const hol=document.createElement('div');
               hol.className='holiday';
               hol.textContent=capitalize(entry.type);
@@ -97,12 +98,28 @@
     }
 
     wrap.appendChild(ul);
+
+    const legend=document.createElement('div');
+    legend.className='legend';
+    [
+      ['Gündüz','g'],
+      ['Nöbet','n'],
+      ['İzin','i'],
+      ['Diğer','d']
+    ].forEach(([text,cls])=>{
+      const span=document.createElement('span');
+      const color=document.createElement('div');
+      color.className='color '+cls;
+      span.appendChild(color);
+      span.appendChild(document.createTextNode(text));
+      legend.appendChild(span);
+    });
+    wrap.appendChild(legend);
+
     cont.appendChild(wrap);
 
     if(typeof setupHolidayCalendar==='function') setupHolidayCalendar(ul);
   }
-
-  function bgColor(t){ return t==='gündüz'? '#0b3e6f' : t==='nöbet'? '#661314' : t==='izin'? '#0f4d2f' : '#3a3a3a'; }
 
   // Modal logic
   const modal = document.getElementById('wls-modal');


### PR DESCRIPTION
## Summary
- fix inconsistent month heights
- color code calendar days by request type
- show legend for request colors
- preview marked days even when month is collapsed

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6845f61e655483308593ae0843ec643a