### PR TITLE
Update Shift header layout

### DIFF
--- a/assets/worklist.css
+++ b/assets/worklist.css
@@ -27,13 +27,20 @@ body.worklist-page section.card {
 
 .wl-header {
   height: 64px;
+  background: rgba(0,0,0,0.3);
+  backdrop-filter: blur(6px);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.4);
+}
+.wl-header-inner {
+  height: 100%;
   display: flex;
   align-items: center;
   justify-content: space-between;
   padding: 0 24px;
-  background: rgba(0,0,0,0.3);
-  backdrop-filter: blur(6px);
-  box-shadow: 0 2px 4px rgba(0,0,0,0.4);
+  box-sizing: border-box;
+  max-width: 1200px;
+  margin: 0 auto;
+  width: 100%;
 }
 .wl-header .left {
   font-weight: 700;

--- a/modules/shift.php
+++ b/modules/shift.php
@@ -17,9 +17,11 @@ function tr_upper(string $text): string {
 <link rel="stylesheet" href="assets/holiday-calendar.css">
 <div id="wls-app">
   <header class="wl-header">
-    <div class="left">
-      <button id="wlSidebarToggle" class="menu-toggle" type="button"><i class="fa-solid fa-bars"></i></button>
-      <a href="index.php" class="home-link">Çalışma Listesi &amp; İstekler</a>
+    <div class="wl-header-inner">
+      <div class="left">
+        <button id="wlSidebarToggle" class="menu-toggle" type="button"><i class="fa-solid fa-bars"></i></button>
+        <a href="index.php" class="home-link">Çalışma Listesi &amp; İstekler</a>
+      </div>
     </div>
   </header>
   <div class="wl-container">


### PR DESCRIPTION
## Summary
- restructure header markup in modules/shift.php
- add `.wl-header-inner` container and styles so header content isn't flush with page edges

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6845ff079db483309a463836227cea07