### PR TITLE
Center header on worklist page

### DIFF
--- a/assets/worklist.css
+++ b/assets/worklist.css
@@ -34,6 +34,10 @@ body.worklist-page section.card {
   background: rgba(0,0,0,0.3);
   backdrop-filter: blur(6px);
   box-shadow: 0 2px 4px rgba(0,0,0,0.4);
+  width: 100%;
+  box-sizing: border-box;
+  max-width: 1200px;
+  margin: 0 auto;
 }
 .wl-header .left {
   font-weight: 700;


### PR DESCRIPTION
## Summary
- center the worklist header so it's not flush with page edges

## Testing
- `npm test` *(fails: no test specified)*
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846000870288330a1e8b57db0cb5e8a