### PR TITLE
Fix shift page header container

### DIFF
--- a/assets/worklist.css
+++ b/assets/worklist.css
@@ -27,13 +27,18 @@ body.worklist-page section.card {
 
 .wl-header {
   height: 64px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0 24px;
   background: rgba(0,0,0,0.3);
   backdrop-filter: blur(6px);
   box-shadow: 0 2px 4px rgba(0,0,0,0.4);
+}
+.wl-header-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 24px;
+  width: 100%;
 }
 .wl-header .left {
   font-weight: 700;

--- a/modules/shift.php
+++ b/modules/shift.php
@@ -17,9 +17,11 @@ function tr_upper(string $text): string {
 <link rel="stylesheet" href="assets/holiday-calendar.css">
 <div id="wls-app">
   <header class="wl-header">
-    <div class="left">
-      <button id="wlSidebarToggle" class="menu-toggle" type="button"><i class="fa-solid fa-bars"></i></button>
-      <a href="index.php" class="home-link">Çalışma Listesi &amp; İstekler</a>
+    <div class="wl-header-container">
+      <div class="left">
+        <button id="wlSidebarToggle" class="menu-toggle" type="button"><i class="fa-solid fa-bars"></i></button>
+        <a href="index.php" class="home-link">Çalışma Listesi &amp; İstekler</a>
+      </div>
     </div>
   </header>
   <div class="wl-container">


### PR DESCRIPTION
## Summary
- wrap shift page header contents in a new `.wl-header-container`
- center that container and limit its width

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684600f64d2c8330b652148b5940807a