### PR TITLE
Improve admin dark mode styles

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -49,6 +49,11 @@ body.dark .card {
   background-color: #1e1e1e;
   color: inherit;
 }
+body.dark .card-header,
+body.dark .card-footer {
+  background-color: #1e1e1e;
+  border-color: #343a40;
+}
 body.dark .navbar {
   background-color: #1f1f1f !important;
 }
@@ -92,6 +97,7 @@ body.dark .bubble.mine .status span {
 body.dark .list-group-item {
   background-color: #1e1e1e;
   color: #f8f9fa;
+  border-color: #343a40;
 }
 body.dark .list-group-item.active {
   background-color: #0d6efd;
@@ -110,6 +116,9 @@ body.dark .modal-footer {
 body.dark .btn-close {
   filter: invert(1);
 }
+body.dark .tab-pane {
+  background-color: #121212;
+}
 
 /* Admin announcements fixes */
 #announcements .list-group-item {
@@ -126,12 +135,21 @@ body.dark .table {
   color: #f8f9fa;
   background-color: #1e1e1e;
 }
+body.dark .table thead {
+  background-color: #1e1e1e;
+}
 body.dark .table th,
 body.dark .table td {
   border-color: #343a40;
 }
 body.dark .table-striped>tbody>tr:nth-of-type(odd) {
   background-color: rgba(255, 255, 255, 0.05);
+}
+body.dark .table-striped>tbody>tr:nth-of-type(even) {
+  background-color: rgba(255, 255, 255, 0.025);
+}
+body.dark .table-responsive {
+  background-color: #1e1e1e;
 }
 body.dark .form-control {
   background-color: #343a40;


### PR DESCRIPTION
## Summary
- update dark theme colors for list groups
- tweak table styling for dark mode
- darken card headers and footers
- ensure tab panes and responsive tables are dark

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6846054516d88330b106a376fff4ecf2