### PR TITLE
Fix dark tables in admin area

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -125,7 +125,12 @@ body.dark .btn-close {
 body.dark .table {
   --bs-table-bg: #1e1e1e;
   --bs-table-color: #f8f9fa;
+  --bs-table-striped-color: #f8f9fa;
   --bs-table-striped-bg: rgba(255, 255, 255, 0.05);
+  --bs-table-hover-color: #f8f9fa;
+  --bs-table-hover-bg: rgba(255, 255, 255, 0.075);
+  --bs-table-active-color: #f8f9fa;
+  --bs-table-active-bg: rgba(255, 255, 255, 0.1);
   --bs-table-border-color: #343a40;
   color: #f8f9fa;
   background-color: #1e1e1e;

--- a/assets/style.css
+++ b/assets/style.css
@@ -123,6 +123,10 @@ body.dark .btn-close {
 
 /* Dark theme tweaks for activity log */
 body.dark .table {
+  --bs-table-bg: #1e1e1e;
+  --bs-table-color: #f8f9fa;
+  --bs-table-striped-bg: rgba(255, 255, 255, 0.05);
+  --bs-table-border-color: #343a40;
   color: #f8f9fa;
   background-color: #1e1e1e;
 }


### PR DESCRIPTION
## Summary
- adjust table styles for dark theme to avoid white backgrounds

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68460823393c833098669ecd8a82e59a