### PR TITLE
Fix login without credentials

### DIFF
--- a/assets/confetti-button.js
+++ b/assets/confetti-button.js
@@ -3,13 +3,19 @@ let disabled = false;
 
 async function loginAndAnimate() {
   if (disabled) return;
+  const username = document.getElementById('username').value.trim();
+  const password = document.getElementById('password').value;
+  if (!username || !password) {
+    showError('Kullanıcı adı ve şifre gerekli');
+    return;
+  }
   disabled = true;
   document.getElementById('login-error').style.display = 'none';
   button.classList.add('loading');
   button.classList.remove('ready');
   const formData = new FormData();
-  formData.append('username', document.getElementById('username').value);
-  formData.append('password', document.getElementById('password').value);
+  formData.append('username', username);
+  formData.append('password', password);
   try {
     const response = await fetch('login_api.php', { method: 'POST', body: formData });
     const result = await response.json();

--- a/pages/login_api.php
+++ b/pages/login_api.php
@@ -7,6 +7,10 @@ header('Content-Type: application/json');
 
 $u = $_POST['username'] ?? '';
 $p = $_POST['password'] ?? '';
+if ($u === '' || $p === '') {
+    echo json_encode(['success' => false, 'error' => 'Kullanıcı adı ve şifre gerekli']);
+    exit;
+}
 $stmt = $pdo->prepare('SELECT username, password, role FROM users WHERE username = ?');
 $stmt->execute([$u]);
 $user = $stmt->fetch();


### PR DESCRIPTION
## Summary
- prevent login attempt if username or password is empty on client side
- validate username and password server-side before attempting login

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684625ad15f08330853ad726e947da36