### PR TITLE
Add register button animations

### DIFF
--- a/assets/register-confetti.js
+++ b/assets/register-confetti.js
@@ -1,0 +1,22 @@
+function showConfetti() {
+    var button = document.getElementById('login-button');
+    if (!button || !window.confetti) return;
+    var rect = button.getBoundingClientRect();
+    var x = (rect.left + rect.width / 2) / window.innerWidth;
+    var y = (rect.top + rect.height / 2) / window.innerHeight;
+    window.confetti({
+        particleCount: 80,
+        spread: 70,
+        origin: { x: x, y: y }
+    });
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+    if (window.registrationSuccess) {
+        var button = document.getElementById('login-button');
+        if (button) {
+            button.classList.add('complete');
+        }
+        showConfetti();
+    }
+});

--- a/pages/register.php
+++ b/pages/register.php
@@ -35,6 +35,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
     <link rel="stylesheet" href="../assets/login.css">
+    <link rel="stylesheet" href="../assets/confetti-button.css">
 </head>
 <body>
     <div class="ring">
@@ -70,7 +71,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     </select>
                 </div>
                 <div class="inputBx">
-                    <input type="submit" value="Kayıt Ol">
+                    <button id="login-button" class="ready" type="submit">
+                        <div class="message submitMessage">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 13 12.2"><polyline stroke="currentColor" points="2,7.1 6.5,11.1 11,7.1"/><line stroke="currentColor" x1="6.5" y1="1.2" x2="6.5" y2="10.3"/></svg>
+                            <span class="button-text">Kayıt Ol</span>
+                        </div>
+                        <div class="message loadingMessage">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 19 17">
+                                <circle class="loadingCircle" cx="2.2" cy="10" r="1.6"/>
+                                <circle class="loadingCircle" cx="9.5" cy="10" r="1.6"/>
+                                <circle class="loadingCircle" cx="16.8" cy="10" r="1.6"/>
+                            </svg>
+                        </div>
+                        <div class="message successMessage">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 13 11"><polyline stroke="currentColor" points="1.4,5.8 5.1,9.5 11.6,2.1"/></svg>
+                            <span class="button-text">Başarılı</span>
+                        </div>
+                    </button>
                 </div>
                 <div class="links">
                     <a href="login.php">Giriş Yap</a>
@@ -81,6 +98,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="../assets/theme.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
+    <script src="../assets/register-confetti.js"></script>
+    <?php if ($message === 'Kayıt başarılı. Giriş yapabilirsiniz.'): ?>
+    <script>window.registrationSuccess = true;</script>
+    <?php endif; ?>
     <script>
         document.querySelectorAll('.toggle-password').forEach(function(el) {
             el.addEventListener('click', function() {


### PR DESCRIPTION
## Summary
- add `register-confetti.js` to trigger confetti on successful registration
- style registration page button with confetti animation
- include confetti assets on the register page

## Testing
- `npm test` *(fails: npm not installed)*
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684626a737c88330ad191d496dd7ab60