### PR TITLE
Add license activation system

### DIFF
--- a/activate.php
+++ b/activate.php
@@ -1,0 +1,50 @@
+<?php
+session_start();
+require __DIR__ . '/includes/db.php';
+require __DIR__ . '/includes/license.php';
+
+$message = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $key = trim($_POST['license_key'] ?? '');
+    if ($key !== '' && verify_license($pdo, $key)) {
+        header('Location: index.php');
+        exit;
+    } else {
+        $message = 'Lisans anahtarı geçersiz.';
+    }
+}
+$expected = generate_license_key();
+?>
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Lisans Aktivasyonu</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+<div class="container py-5">
+    <div class="row justify-content-center">
+        <div class="col-md-6">
+            <div class="card">
+                <div class="card-body">
+                    <h3 class="card-title mb-4">Lisans Aktivasyonu</h3>
+                    <?php if($message): ?>
+                        <div class="alert alert-danger"><?php echo htmlspecialchars($message); ?></div>
+                    <?php endif; ?>
+                    <form method="post">
+                        <div class="mb-3">
+                            <label for="license_key" class="form-label">Lisans Anahtarı</label>
+                            <input type="text" class="form-control" name="license_key" id="license_key" required>
+                        </div>
+                        <button class="btn btn-primary">Aktive Et</button>
+                    </form>
+                    <p class="mt-3 text-muted">Bu demo için beklenen anahtar: <code><?php echo $expected; ?></code></p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/activate.php
+++ b/activate.php
@@ -1,7 +1,7 @@
 <?php
 session_start();
 require __DIR__ . '/includes/db.php';
-require __DIR__ . '/includes/license.php';
+require_once __DIR__ . '/includes/license.php';
 
 $message = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {

--- a/includes/db.php
+++ b/includes/db.php
@@ -25,6 +25,8 @@ try {
         FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
         FOREIGN KEY (muted_user_id) REFERENCES users(id) ON DELETE CASCADE
     )");
+    require_once __DIR__ . '/license.php';
+    enforce_license($pdo);
 } catch (PDOException $e) {
     die('Veritabanı bağlantı hatası: ' . $e->getMessage());
 }

--- a/includes/license.php
+++ b/includes/license.php
@@ -1,0 +1,44 @@
+<?php
+// Simple license management
+function license_setup(PDO $pdo){
+    $pdo->exec("CREATE TABLE IF NOT EXISTS license (
+        id INT PRIMARY KEY,
+        license_key VARCHAR(255) NOT NULL,
+        verified TINYINT(1) NOT NULL DEFAULT 0
+    )");
+}
+
+function generate_license_key(): string {
+    // Generate expected license for current domain
+    $secret = 'MY_SECRET_SALT';
+    $domain = $_SERVER['HTTP_HOST'] ?? 'localhost';
+    return hash('sha256', $domain . $secret);
+}
+
+function is_license_valid(PDO $pdo): bool {
+    license_setup($pdo);
+    $stmt = $pdo->query("SELECT verified FROM license WHERE id=1");
+    return $stmt->fetchColumn() == 1;
+}
+
+function verify_license(PDO $pdo, string $key): bool {
+    $expected = generate_license_key();
+    if (hash_equals($expected, $key)) {
+        license_setup($pdo);
+        $stmt = $pdo->prepare("REPLACE INTO license (id, license_key, verified) VALUES (1, ?, 1)");
+        $stmt->execute([$key]);
+        return true;
+    }
+    return false;
+}
+
+function enforce_license(PDO $pdo){
+    if (basename($_SERVER['SCRIPT_NAME']) === 'activate.php') {
+        return;
+    }
+    if (!is_license_valid($pdo)) {
+        header('Location: /activate.php');
+        exit;
+    }
+}
+?>


### PR DESCRIPTION
## Summary
- enforce license check via `license.php`
- add activation page with form for license key
- run `npm test` (fails: no test specified)

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68462e7f99408330bac4780d48b0619f